### PR TITLE
[Feature] 프로필 수정 API

### DIFF
--- a/backend/src/app/myinfo/dto/profile-modifying-request.dto.ts
+++ b/backend/src/app/myinfo/dto/profile-modifying-request.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsUrl } from 'class-validator';
+
+export class ProfileModifyingRequest {
+  @ApiProperty({
+    example: 'pythonstrup',
+    description: 'userName',
+    required: true,
+  })
+  @IsString()
+  userName: string;
+
+  @ApiProperty({
+    example:
+      'https://kr.object.ncloudstorage.com/uploads/images/1669276833875-64adca9c-94cd-4162-a53f-f75e951e39db',
+    description: '프로필 이미지',
+    required: true,
+  })
+  @IsString()
+  profileImage: string;
+
+  @ApiProperty({
+    example: '안녕하세요 웹풀스택 개발자 pythonstrup입니다!',
+    description: '간단한 자기소개',
+    required: true,
+  })
+  @IsString()
+  description: string;
+
+  @ApiProperty({
+    example: 'https://github.com/pythonstrup',
+    description: '깃허브 주소',
+    required: true,
+  })
+  @IsUrl()
+  githubUrl: string;
+
+  @ApiProperty({
+    example: 'https://myvelop.tistory.com/',
+    description: '블로그 주소',
+    required: true,
+  })
+  @IsUrl()
+  blogUrl: string;
+}

--- a/backend/src/app/myinfo/exception/username-duplicate.exception.ts
+++ b/backend/src/app/myinfo/exception/username-duplicate.exception.ts
@@ -4,6 +4,6 @@ export class UserNameDuplicateException extends BadRequestException {
   constructor(
     message = '중복된 유저이름으로 요청했습니다! 해당 유저이름으로 바꿀 수 없습니다.',
   ) {
-    super({ status: 'USER_NAME_BAD_REQUEST', message });
+    super({ status: 'USER_NAME_DUPLICATE_BAD_REQUEST', message });
   }
 }

--- a/backend/src/app/myinfo/exception/username-duplicate.exception.ts
+++ b/backend/src/app/myinfo/exception/username-duplicate.exception.ts
@@ -1,0 +1,9 @@
+import { BadRequestException } from '@nestjs/common';
+
+export class UserNameDuplicateException extends BadRequestException {
+  constructor(
+    message = '중복된 유저이름으로 요청했습니다! 해당 유저이름으로 바꿀 수 없습니다.',
+  ) {
+    super({ status: 'USER_NAME_BAD_REQUEST', message });
+  }
+}

--- a/backend/src/app/myinfo/myinfo.controller.ts
+++ b/backend/src/app/myinfo/myinfo.controller.ts
@@ -9,7 +9,7 @@ import { CurrentUser } from '@src/common/decorator/current-user.decorator';
 import { User } from '@app/user/entity/user.entity';
 import { ProfileModifyingRequest } from '@app/myinfo/dto/profile-modifying-request.dto';
 import { ApiErrorResponse } from '@src/common/decorator/api-error-response.decorator';
-import { UserNameDuplicateException } from './exception/username-duplicate.exception';
+import { UserNameDuplicateException } from '@app/myinfo/exception/username-duplicate.exception';
 
 @Controller('/my-info')
 @JwtAuth()

--- a/backend/src/app/myinfo/myinfo.controller.ts
+++ b/backend/src/app/myinfo/myinfo.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpStatus, Put } from '@nestjs/common';
+import { Body, Controller, Get, HttpStatus, Put } from '@nestjs/common';
 import { JwtAuth } from '@src/common/decorator/jwt-auth.decorator';
 import { MyInfoService } from '@app/myinfo/myinfo.service';
 import { ApiTags } from '@nestjs/swagger';
@@ -7,6 +7,9 @@ import { MyInfoGetResponse } from '@app/myinfo/dto/myinfo-get-response.dto';
 import { ResponseEntity } from '@src/common/response-entity';
 import { CurrentUser } from '@src/common/decorator/current-user.decorator';
 import { User } from '@app/user/entity/user.entity';
+import { ProfileModifyingRequest } from '@app/myinfo/dto/profile-modifying-request.dto';
+import { ApiErrorResponse } from '@src/common/decorator/api-error-response.decorator';
+import { UserNameDuplicateException } from './exception/username-duplicate.exception';
 
 @Controller('/my-info')
 @JwtAuth()
@@ -14,15 +17,25 @@ import { User } from '@app/user/entity/user.entity';
 export class MyInfoController {
   constructor(private readonly myInfoService: MyInfoService) {}
 
-  @Get()
+  @Get('/')
   @ApiSuccessResponse(HttpStatus.OK, MyInfoGetResponse)
   async getMyInfo(@CurrentUser() user: User) {
     const data = MyInfoGetResponse.from(user);
     return ResponseEntity.OK_WITH_DATA(data);
   }
 
-  @Put()
-  modifyMyInfo() {
-    return '';
+  @Put('/')
+  @ApiSuccessResponse(HttpStatus.NO_CONTENT)
+  @ApiErrorResponse(UserNameDuplicateException)
+  async modifyProfile(
+    @CurrentUser() user: User,
+    @Body() profileModifyingRequest: ProfileModifyingRequest,
+  ) {
+    await this.myInfoService.modifyProfile(
+      user.id,
+      user.userName,
+      profileModifyingRequest,
+    );
+    return ResponseEntity.NO_CONTENT();
   }
 }

--- a/backend/src/app/myinfo/myinfo.controller.ts
+++ b/backend/src/app/myinfo/myinfo.controller.ts
@@ -31,11 +31,7 @@ export class MyInfoController {
     @CurrentUser() user: User,
     @Body() profileModifyingRequest: ProfileModifyingRequest,
   ) {
-    await this.myInfoService.modifyProfile(
-      user.id,
-      user.userName,
-      profileModifyingRequest,
-    );
+    await this.myInfoService.updateProfile(user, profileModifyingRequest);
     return ResponseEntity.NO_CONTENT();
   }
 }

--- a/backend/src/app/myinfo/myinfo.service.ts
+++ b/backend/src/app/myinfo/myinfo.service.ts
@@ -1,7 +1,31 @@
 import { Injectable } from '@nestjs/common';
 import { UserRepository } from '@app/user/user.repository';
+import { ProfileModifyingRequest } from '@app/myinfo/dto/profile-modifying-request.dto';
+import { UserNameDuplicateException } from './exception/username-duplicate.exception';
 
 @Injectable()
 export class MyInfoService {
   constructor(private readonly userRepository: UserRepository) {}
+
+  async modifyProfile(
+    userId: number,
+    userName: string,
+    profileModifyingRequest: ProfileModifyingRequest,
+  ) {
+    const user = await this.userRepository.findByUsername(
+      profileModifyingRequest.userName,
+    );
+    if (user && userName !== profileModifyingRequest.userName) {
+      throw new UserNameDuplicateException();
+    }
+
+    this.userRepository.updateUser({
+      id: userId,
+      userName: profileModifyingRequest.userName,
+      profileImage: profileModifyingRequest.profileImage,
+      description: profileModifyingRequest.description,
+      githubUrl: profileModifyingRequest.githubUrl,
+      blogUrl: profileModifyingRequest.blogUrl,
+    });
+  }
 }

--- a/backend/src/app/myinfo/myinfo.service.ts
+++ b/backend/src/app/myinfo/myinfo.service.ts
@@ -2,30 +2,27 @@ import { Injectable } from '@nestjs/common';
 import { UserRepository } from '@app/user/user.repository';
 import { ProfileModifyingRequest } from '@app/myinfo/dto/profile-modifying-request.dto';
 import { UserNameDuplicateException } from '@app/myinfo/exception/username-duplicate.exception';
+import { User } from '../user/entity/user.entity';
 
 @Injectable()
 export class MyInfoService {
   constructor(private readonly userRepository: UserRepository) {}
 
-  async modifyProfile(
-    userId: number,
-    userName: string,
-    ModifyingContents: ProfileModifyingRequest,
-  ) {
-    const user = await this.userRepository.findByUsername(
+  async updateProfile(user: User, ModifyingContents: ProfileModifyingRequest) {
+    const currentUser = await this.userRepository.findByUsername(
       ModifyingContents.userName,
     );
-    if (user && userName !== ModifyingContents.userName) {
+    if (currentUser && user.userName !== ModifyingContents.userName) {
       throw new UserNameDuplicateException();
     }
 
-    this.userRepository.updateUser({
-      id: userId,
+    user.updateProfile({
       userName: ModifyingContents.userName,
       profileImage: ModifyingContents.profileImage,
       description: ModifyingContents.description,
       githubUrl: ModifyingContents.githubUrl,
       blogUrl: ModifyingContents.blogUrl,
     });
+    this.userRepository.updateUser(user);
   }
 }

--- a/backend/src/app/myinfo/myinfo.service.ts
+++ b/backend/src/app/myinfo/myinfo.service.ts
@@ -10,22 +10,22 @@ export class MyInfoService {
   async modifyProfile(
     userId: number,
     userName: string,
-    profileModifyingRequest: ProfileModifyingRequest,
+    ModifyingContents: ProfileModifyingRequest,
   ) {
     const user = await this.userRepository.findByUsername(
-      profileModifyingRequest.userName,
+      ModifyingContents.userName,
     );
-    if (user && userName !== profileModifyingRequest.userName) {
+    if (user && userName !== ModifyingContents.userName) {
       throw new UserNameDuplicateException();
     }
 
     this.userRepository.updateUser({
       id: userId,
-      userName: profileModifyingRequest.userName,
-      profileImage: profileModifyingRequest.profileImage,
-      description: profileModifyingRequest.description,
-      githubUrl: profileModifyingRequest.githubUrl,
-      blogUrl: profileModifyingRequest.blogUrl,
+      userName: ModifyingContents.userName,
+      profileImage: ModifyingContents.profileImage,
+      description: ModifyingContents.description,
+      githubUrl: ModifyingContents.githubUrl,
+      blogUrl: ModifyingContents.blogUrl,
     });
   }
 }

--- a/backend/src/app/myinfo/myinfo.service.ts
+++ b/backend/src/app/myinfo/myinfo.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { UserRepository } from '@app/user/user.repository';
 import { ProfileModifyingRequest } from '@app/myinfo/dto/profile-modifying-request.dto';
-import { UserNameDuplicateException } from './exception/username-duplicate.exception';
+import { UserNameDuplicateException } from '@app/myinfo/exception/username-duplicate.exception';
 
 @Injectable()
 export class MyInfoService {

--- a/backend/src/app/user/entity/user.entity.ts
+++ b/backend/src/app/user/entity/user.entity.ts
@@ -12,7 +12,7 @@ export class User {
   @PrimaryGeneratedColumn({ unsigned: true })
   id: number;
 
-  @Column({ type: 'varchar', length: 100 })
+  @Column({ type: 'varchar', length: 100, unique: true })
   userName: string;
 
   @Column({ type: 'varchar', length: 400, default: '' })
@@ -40,7 +40,7 @@ export class User {
   updatedAt: Date;
 
   @Column({ type: 'timestamp', nullable: true })
-  deletedAt: Date;
+  deletedAt: Date | null;
 
   static signup({
     socialId,

--- a/backend/src/app/user/entity/user.entity.ts
+++ b/backend/src/app/user/entity/user.entity.ts
@@ -64,4 +64,24 @@ export class User {
     user.userName = randomUUID();
     return user;
   }
+
+  updateProfile({
+    userName,
+    profileImage,
+    description,
+    blogUrl,
+    githubUrl,
+  }: {
+    userName: string;
+    profileImage: string;
+    description: string;
+    blogUrl: string;
+    githubUrl: string;
+  }) {
+    this.userName = userName;
+    this.profileImage = profileImage;
+    this.blogUrl = blogUrl;
+    this.description = description;
+    this.githubUrl = githubUrl;
+  }
 }

--- a/backend/src/app/user/user.repository.ts
+++ b/backend/src/app/user/user.repository.ts
@@ -24,29 +24,15 @@ export class UserRepository extends Repository<User> {
     return this.findOneBy({ id, deletedAt: null });
   }
 
-  updateUser({
-    id,
-    userName,
-    profileImage,
-    description,
-    githubUrl,
-    blogUrl,
-  }: {
-    id: number;
-    userName: string;
-    profileImage: string;
-    description: string;
-    githubUrl: string;
-    blogUrl: string;
-  }) {
+  updateUser(user: User) {
     return this.update(
-      { id },
+      { id: user.id },
       {
-        userName,
-        profileImage,
-        description,
-        githubUrl,
-        blogUrl,
+        userName: user.userName,
+        profileImage: user.profileImage,
+        description: user.description,
+        githubUrl: user.githubUrl,
+        blogUrl: user.blogUrl,
       },
     );
   }

--- a/backend/src/app/user/user.repository.ts
+++ b/backend/src/app/user/user.repository.ts
@@ -23,4 +23,31 @@ export class UserRepository extends Repository<User> {
   findById(id: number) {
     return this.findOneBy({ id });
   }
+
+  updateUser({
+    id,
+    userName,
+    profileImage,
+    description,
+    githubUrl,
+    blogUrl,
+  }: {
+    id: number;
+    userName: string;
+    profileImage: string;
+    description: string;
+    githubUrl: string;
+    blogUrl: string;
+  }) {
+    return this.update(
+      { id },
+      {
+        userName,
+        profileImage,
+        description,
+        githubUrl,
+        blogUrl,
+      },
+    );
+  }
 }

--- a/backend/src/app/user/user.repository.ts
+++ b/backend/src/app/user/user.repository.ts
@@ -13,15 +13,15 @@ export class UserRepository extends Repository<User> {
   }
 
   findBySocial(socialId: string, socialType: string) {
-    return this.findOneBy({ socialId, socialType });
+    return this.findOneBy({ socialId, socialType, deletedAt: null });
   }
 
   findByUsername(userName: string) {
-    return this.findOneBy({ userName });
+    return this.findOneBy({ userName, deletedAt: null });
   }
 
   findById(id: number) {
-    return this.findOneBy({ id });
+    return this.findOneBy({ id, deletedAt: null });
   }
 
   updateUser({

--- a/backend/src/common/decorator/api-success-resposne.decorator.ts
+++ b/backend/src/common/decorator/api-success-resposne.decorator.ts
@@ -25,7 +25,7 @@ export function ApiSuccessResponse(
   return applyDecorators(
     HttpCode(status),
     ApiResponse({
-      type: dataType && Temp,
+      type: HttpStatus.NO_CONTENT === status ? undefined : dataType && Temp,
       status,
       description: HttpStatus[status],
     }),

--- a/backend/src/common/guard/jwt-auth.guard.ts
+++ b/backend/src/common/guard/jwt-auth.guard.ts
@@ -31,7 +31,7 @@ export class JwtAuthGuard implements CanActivate {
 
         const user = await this.dataSource
           .getRepository(User)
-          .findOneBy({ id: authTokenPayload.userId });
+          .findOneBy({ id: authTokenPayload.userId, deletedAt: null });
 
         if (!user) throw new Error('유저가 존재하지 않습니다');
 
@@ -48,7 +48,7 @@ export class JwtAuthGuard implements CanActivate {
 
         const user = await this.dataSource
           .getRepository(User)
-          .findOneBy({ id: authTokenPayload.userId });
+          .findOneBy({ id: authTokenPayload.userId, deletedAt: null });
 
         if (!user) throw new Error('Not Found User');
 

--- a/backend/src/common/response-entity.ts
+++ b/backend/src/common/response-entity.ts
@@ -24,6 +24,10 @@ export class ResponseEntity<T> {
     return new ResponseEntity<T>('CREATED', '', data);
   }
 
+  static NO_CONTENT() {
+    return new ResponseEntity<string>('NO_CONTENT', '', '');
+  }
+
   static ERROR() {
     return new ResponseEntity<string>(
       'INTERNAL_SERVER_ERROR',


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 프로필 수정 API

## 고민

### 꼭 Request DTO를 풀어헤쳐서 Service에 넘겨야하는가?

- 어차피 바뀌는 내용이 없는데 DTO를 그냥 넘기면 안 될까..?
- 팀원과의 합의
  - 물론 DTO를 풀어헤쳐서 Service에 넘겨주면 Request에 대한 의존성이 줄어들기 때문에 얻을 수 있는 이점들이 있다. 
    - side effect를 줄일 수 있다.
    - 같은 경로에서 요청이 바뀌었을 때의 유연성, 확장성을 챙길 수 있다.
  - 하지만 위의 이점을 얻을 정도로 중요하지 않거나, 복잡하지 않은 로직에는 DTO를 그냥 전달하는 것이 생산성 측면에서 더 좋지 않을까?
  - 엄청 크리티컬한 로직이 아니라면 굳이 풀어헤쳐서 Service에 전달하는 것이 아닌, Request를 그냥 전달하자고 합의했다.

![image](https://user-images.githubusercontent.com/90585081/204471651-329003f5-2b92-4d0f-be2e-7e81925b771f.png)

### 위를 이어서.. 공부

- [DTO의 사용 범위에 대하여 - 원본](https://tecoble.techcourse.co.kr/post/2021-04-25-dto-layer-scope/)
- [DTO의 사용 범위에 대하여 - 위 링크의 Nest 버전](https://overcome-the-limits.tistory.com/648)
- `toEntity()` 메소드를 이용해 새로운 인스턴스를 반환해주는 모습이다. 참고할만 하다.


## 비고

- 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
