### PR TITLE
[BUGFIX] userName 중복 확인 API

### DIFF
--- a/backend/src/app/user/user.controller.ts
+++ b/backend/src/app/user/user.controller.ts
@@ -36,8 +36,10 @@ export class UserController {
   @Post('username/is-occupied')
   @JwtAuth()
   @ApiSuccessResponse(HttpStatus.OK, UserNameUniqueResponse)
-  checkUsernameUnique(@Body() userNameUniqueRequest: UserNameUniqueRequest) {
-    const result = this.userService.checkUsernameUnique(
+  async checkUsernameUnique(
+    @Body() userNameUniqueRequest: UserNameUniqueRequest,
+  ) {
+    const result = await this.userService.checkUsernameUnique(
       userNameUniqueRequest.userName,
     );
     const data = UserNameUniqueResponse.from(result);

--- a/backend/src/app/user/user.repository.ts
+++ b/backend/src/app/user/user.repository.ts
@@ -1,4 +1,4 @@
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, IsNull, Repository } from 'typeorm';
 import { User } from '@app/user/entity/user.entity';
 import { Injectable } from '@nestjs/common';
 
@@ -13,15 +13,15 @@ export class UserRepository extends Repository<User> {
   }
 
   findBySocial(socialId: string, socialType: string) {
-    return this.findOneBy({ socialId, socialType, deletedAt: null });
+    return this.findOneBy({ socialId, socialType, deletedAt: IsNull() });
   }
 
   findByUsername(userName: string) {
-    return this.findOneBy({ userName, deletedAt: null });
+    return this.findOneBy({ userName });
   }
 
   findById(id: number) {
-    return this.findOneBy({ id, deletedAt: null });
+    return this.findOneBy({ id, deletedAt: IsNull() });
   }
 
   updateUser(user: User) {

--- a/backend/src/app/user/user.service.ts
+++ b/backend/src/app/user/user.service.ts
@@ -6,8 +6,9 @@ import { UserNotFoundException } from '@app/user/exception/user-not-found.except
 export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
-  checkUsernameUnique(userName: string) {
-    return this.userRepository.findByUsername(userName) ? false : true;
+  async checkUsernameUnique(userName: string) {
+    const user = await this.userRepository.findByUsername(userName);
+    return user ? true : false;
   }
 
   async findUserById(id: number) {


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 버그 내용
  - 유저정보가 Promise로 Pending되어 있어서 null값인 것들도 Promise로 리턴되어서 모든 값이 모든 값이 true로 반환되어버리는 에러가 발생합니다.  

- 유저 중복 체크 실패 디버그
  - async/await를 활용해 Promise를 풀어줌 
