### PR TITLE
[Feature] 사용자 알림 설정 상태 수정 및 조회 API

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { UserModule } from '@app/user/user.module';
 import { MyInfoModule } from '@app/myinfo/myinfo.module';
 import { CookieConfigModule } from '@config/cookie/config.module';
 import { GroupApplicationModule } from '@app/group-application/group-application.module';
+import { NotificationModule } from '@app/notification/notification.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { GroupApplicationModule } from '@app/group-application/group-application
     UserModule,
     MyInfoModule,
     GroupApplicationModule,
+    NotificationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/app/notification/constants/notification.constants.ts
+++ b/backend/src/app/notification/constants/notification.constants.ts
@@ -1,0 +1,9 @@
+export enum NOTIFICATION_SETTING_TYPE {
+  COMMENT = 'COMMENT',
+  GROUP = 'GROUP',
+}
+
+export enum NOTIFICATION_SETTING_STATUS {
+  OFF,
+  ON,
+}

--- a/backend/src/app/notification/constants/notification.constants.ts
+++ b/backend/src/app/notification/constants/notification.constants.ts
@@ -4,6 +4,6 @@ export enum NOTIFICATION_SETTING_TYPE {
 }
 
 export enum NOTIFICATION_SETTING_STATUS {
-  OFF,
-  ON,
+  ON = 'ON',
+  OFF = 'OFF',
 }

--- a/backend/src/app/notification/dto/get-notification-settings-response.dto.ts
+++ b/backend/src/app/notification/dto/get-notification-settings-response.dto.ts
@@ -1,0 +1,31 @@
+import {
+  NOTIFICATION_SETTING_STATUS,
+  NOTIFICATION_SETTING_TYPE,
+} from '@app/notification/constants/notification.constants';
+import { ApiProperty } from '@nestjs/swagger';
+import { NotificationSetting } from '@app/notification/entity/notification-setting.entity';
+
+export class GetNotificationSettingsResponse {
+  @ApiProperty({ example: 1, description: '알림설정아이디' })
+  id: number;
+
+  @ApiProperty({
+    example: NOTIFICATION_SETTING_TYPE.GROUP,
+    description: '알림설정타입',
+  })
+  type: NOTIFICATION_SETTING_TYPE;
+
+  @ApiProperty({
+    example: NOTIFICATION_SETTING_STATUS.ON,
+    description: '알림설정상태',
+  })
+  status: NOTIFICATION_SETTING_STATUS;
+
+  static from(notificationSetting: NotificationSetting) {
+    const res = new GetNotificationSettingsResponse();
+    res.id = notificationSetting.id;
+    res.type = notificationSetting.type;
+    res.status = notificationSetting.status;
+    return res;
+  }
+}

--- a/backend/src/app/notification/dto/patch-notification-setting-request.dto.ts
+++ b/backend/src/app/notification/dto/patch-notification-setting-request.dto.ts
@@ -1,0 +1,14 @@
+import { NOTIFICATION_SETTING_STATUS } from '@app/notification/constants/notification.constants';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+
+export class PatchNotificationSettingRequest {
+  @ApiProperty({
+    enum: NOTIFICATION_SETTING_STATUS,
+    example: NOTIFICATION_SETTING_STATUS.ON,
+    description: '알림상태(ON|OFF)',
+    required: true,
+  })
+  @IsEnum(NOTIFICATION_SETTING_STATUS)
+  status: NOTIFICATION_SETTING_STATUS;
+}

--- a/backend/src/app/notification/entity/notification-setting.entity.ts
+++ b/backend/src/app/notification/entity/notification-setting.entity.ts
@@ -12,6 +12,7 @@ import {
   NOTIFICATION_SETTING_STATUS,
   NOTIFICATION_SETTING_TYPE,
 } from '@app/notification/constants/notification.constants';
+import { NotAccessibleException } from '@app/notification/exception/not-accessible.exception';
 
 @Entity({ name: 'notification_setting' })
 export class NotificationSetting {
@@ -44,5 +45,13 @@ export class NotificationSetting {
     notificationSetting.type = type;
     notificationSetting.status = NOTIFICATION_SETTING_STATUS.ON;
     return notificationSetting;
+  }
+
+  setStatus(user: User, status: NOTIFICATION_SETTING_STATUS) {
+    if (this.userId !== user.id) {
+      throw new NotAccessibleException();
+    }
+
+    this.status = status;
   }
 }

--- a/backend/src/app/notification/entity/notification-setting.entity.ts
+++ b/backend/src/app/notification/entity/notification-setting.entity.ts
@@ -28,7 +28,7 @@ export class NotificationSetting {
   @Column({ type: 'varchar', length: 200 })
   type: NOTIFICATION_SETTING_TYPE;
 
-  @Column({ type: 'tinyint', precision: 1 })
+  @Column({ type: 'varchar', length: 10 })
   status: NOTIFICATION_SETTING_STATUS;
 
   @CreateDateColumn({ type: 'timestamp' })

--- a/backend/src/app/notification/entity/notification-setting.entity.ts
+++ b/backend/src/app/notification/entity/notification-setting.entity.ts
@@ -8,6 +8,10 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { User } from '@app/user/entity/user.entity';
+import {
+  NOTIFICATION_SETTING_STATUS,
+  NOTIFICATION_SETTING_TYPE,
+} from '@app/notification/constants/notification.constants';
 
 @Entity({ name: 'notification_setting' })
 export class NotificationSetting {
@@ -22,14 +26,23 @@ export class NotificationSetting {
   user: Promise<User>;
 
   @Column({ type: 'varchar', length: 200 })
-  type: string;
+  type: NOTIFICATION_SETTING_TYPE;
 
   @Column({ type: 'tinyint', precision: 1 })
-  status: number;
+  status: NOTIFICATION_SETTING_STATUS;
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;
 
   @UpdateDateColumn({ type: 'timestamp' })
   updatedAt: Date;
+
+  static create(user: User, type: NOTIFICATION_SETTING_TYPE) {
+    const notificationSetting = new NotificationSetting();
+    notificationSetting.userId = user.id;
+    notificationSetting.user = Promise.resolve(user);
+    notificationSetting.type = type;
+    notificationSetting.status = NOTIFICATION_SETTING_STATUS.ON;
+    return notificationSetting;
+  }
 }

--- a/backend/src/app/notification/exception/not-accessible.exception.ts
+++ b/backend/src/app/notification/exception/not-accessible.exception.ts
@@ -1,0 +1,7 @@
+import { ForbiddenException } from '@nestjs/common';
+
+export class NotAccessibleException extends ForbiddenException {
+  constructor(message = '정보에 접근할 수 없습니다') {
+    super({ status: 'NOT_ACCESSIBLE', message });
+  }
+}

--- a/backend/src/app/notification/exception/notification-setting-not-found.exception.ts
+++ b/backend/src/app/notification/exception/notification-setting-not-found.exception.ts
@@ -1,0 +1,7 @@
+import { NotFoundException } from '@nestjs/common';
+
+export class NotificationSettingNotFoundException extends NotFoundException {
+  constructor(message = '알림설정 데이터가 존재하지 않습니다') {
+    super({ status: 'NOTIFICATION_SETTING_NOT_FOUND', message });
+  }
+}

--- a/backend/src/app/notification/notification.controller.ts
+++ b/backend/src/app/notification/notification.controller.ts
@@ -1,6 +1,35 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, HttpStatus } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { NotificationSettingRepository } from '@app/notification/repository/notification-setting.repository';
+import { ApiSuccessResponse } from '@decorator/api-success-resposne.decorator';
+import { JwtAuth } from '@decorator/jwt-auth.decorator';
+import { CurrentUser } from '@decorator/current-user.decorator';
+import { User } from '@app/user/entity/user.entity';
+import { ResponseEntity } from '@common/response-entity';
+import { GetNotificationSettingsResponse } from '@app/notification/dto/get-notification-settings-response.dto';
 
 @Controller('notifications')
 @ApiTags('Notification')
-export class NotificationController {}
+export class NotificationController {
+  constructor(
+    private readonly notificationSettingRepository: NotificationSettingRepository,
+  ) {}
+
+  @Get('settings')
+  @JwtAuth()
+  @ApiSuccessResponse(HttpStatus.OK, GetNotificationSettingsResponse, {
+    isArray: true,
+  })
+  async settings(@CurrentUser() user: User) {
+    const notificationSettings =
+      await this.notificationSettingRepository.findBy({
+        userId: user.id,
+      });
+
+    return ResponseEntity.OK_WITH_DATA(
+      notificationSettings.map((notificationSetting) =>
+        GetNotificationSettingsResponse.from(notificationSetting),
+      ),
+    );
+  }
+}

--- a/backend/src/app/notification/notification.controller.ts
+++ b/backend/src/app/notification/notification.controller.ts
@@ -1,0 +1,6 @@
+import { Controller } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+@Controller('notifications')
+@ApiTags('Notification')
+export class NotificationController {}

--- a/backend/src/app/notification/notification.controller.ts
+++ b/backend/src/app/notification/notification.controller.ts
@@ -47,7 +47,7 @@ export class NotificationController {
     );
   }
 
-  @Patch('settings/:id')
+  @Patch('settings/:id/status')
   @JwtAuth()
   @ApiSuccessResponse(HttpStatus.NO_CONTENT)
   @ApiErrorResponse(

--- a/backend/src/app/notification/notification.module.ts
+++ b/backend/src/app/notification/notification.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { NotificationController } from '@app/notification/notification.controller';
+
+@Module({
+  controllers: [NotificationController],
+})
+export class NotificationModule {}

--- a/backend/src/app/notification/notification.module.ts
+++ b/backend/src/app/notification/notification.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { NotificationController } from '@app/notification/notification.controller';
 import { NotificationSettingRepository } from '@app/notification/repository/notification-setting.repository';
+import { NotificationService } from '@app/notification/notification.service';
 
 @Module({
   controllers: [NotificationController],
-  providers: [NotificationSettingRepository],
+  providers: [NotificationService, NotificationSettingRepository],
 })
 export class NotificationModule {}

--- a/backend/src/app/notification/notification.module.ts
+++ b/backend/src/app/notification/notification.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { NotificationController } from '@app/notification/notification.controller';
+import { NotificationSettingRepository } from '@app/notification/repository/notification-setting.repository';
 
 @Module({
   controllers: [NotificationController],
+  providers: [NotificationSettingRepository],
 })
 export class NotificationModule {}

--- a/backend/src/app/notification/notification.service.ts
+++ b/backend/src/app/notification/notification.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { NotificationSettingRepository } from '@app/notification/repository/notification-setting.repository';
+import { User } from '@app/user/entity/user.entity';
+import { NotificationSettingNotFoundException } from '@app/notification/exception/notification-setting-not-found.exception';
+import { NOTIFICATION_SETTING_STATUS } from '@app/notification/constants/notification.constants';
+
+@Injectable()
+export class NotificationService {
+  constructor(
+    private readonly notificationSettingRepository: NotificationSettingRepository,
+  ) {}
+
+  async updateStatus(
+    user: User,
+    id: number,
+    status: NOTIFICATION_SETTING_STATUS,
+  ) {
+    const notificationSetting =
+      await this.notificationSettingRepository.findOneBy({
+        id,
+      });
+
+    if (!notificationSetting) {
+      throw new NotificationSettingNotFoundException();
+    }
+
+    notificationSetting.setStatus(user, status);
+
+    await this.notificationSettingRepository.save(notificationSetting);
+  }
+}

--- a/backend/src/app/notification/repository/notification-setting.repository.ts
+++ b/backend/src/app/notification/repository/notification-setting.repository.ts
@@ -1,0 +1,14 @@
+import { DataSource, Repository } from 'typeorm';
+import { NotificationSetting } from '@app/notification/entity/notification-setting.entity';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NotificationSettingRepository extends Repository<NotificationSetting> {
+  constructor(private readonly dataSource: DataSource) {
+    super(
+      NotificationSetting,
+      dataSource.createEntityManager(),
+      dataSource.createQueryRunner(),
+    );
+  }
+}

--- a/backend/src/setSwagger.ts
+++ b/backend/src/setSwagger.ts
@@ -7,6 +7,7 @@ import { GroupArticleModule } from '@app/group-article/group-article.module';
 import { UserModule } from '@app/user/user.module';
 import { MyInfoModule } from '@app/myinfo/myinfo.module';
 import { GroupApplicationModule } from '@app/group-application/group-application.module';
+import { NotificationModule } from '@app/notification/notification.module';
 
 export const setSwagger = (app: INestApplication) => {
   const config = new DocumentBuilder()
@@ -29,6 +30,7 @@ export const setSwagger = (app: INestApplication) => {
       UserModule,
       MyInfoModule,
       GroupApplicationModule,
+      NotificationModule,
     ],
     extraModels: [ResponseEntity],
   });


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

### 첫 로그인시 알림 설정 정보 추가 되도록 수정

- 기존에는 로그인 했을 때, 알림설정정보를 추가하지 않고 있었습니다. 추가해주었어요.

### `GET /v1/notifications/settings` 알림설정조회 API 추가

- 자신의 알림설정정보를 조회합니다

### `PATCH /v1/notifications/settings/:id/status` 알림설정상태 수정 API 추가

- 알림설정 변경 API 추가: 설정을 ON|OFF로 변경합니다
- 해당 설정 정보가 없는 경우 NotificationSettingNotFoundException 반환
- 자신의 설정이 아닌 경우 NotAccessibleException 반환

## 문제 상황과 해결

- 작업 중 마주한 문제상황 및 해결방법을 남겨주세요.

## 비고

- 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
