### PR TITLE
[BUGFIX] 모집 게시글 카드 너비 수정

### DIFF
--- a/frontend/src/components/common/GroupArticleCard/index.tsx
+++ b/frontend/src/components/common/GroupArticleCard/index.tsx
@@ -1,4 +1,4 @@
-import { Image } from '@mantine/core';
+import Image from 'next/image';
 
 import ArticleTag from '@components/common/ArticleTag';
 import {
@@ -6,6 +6,7 @@ import {
   CardWrapper,
   ClosedText,
   DimmedBox,
+  ImageWrapper,
   InfoWrapper,
   TagWrapper,
   TitleText,
@@ -29,7 +30,9 @@ const GroupArticleCard = ({ article }: Props) => {
           <ClosedText>모집 종료</ClosedText>
         </DimmedBox>
       )}
-      <Image src={article.thumbnail} alt={'thumbnail-image'} height={200} />
+      <ImageWrapper>
+        <Image src={article.thumbnail} alt={'thumbnail-image'} layout="fill" objectFit="cover" />
+      </ImageWrapper>
       <InfoWrapper>
         <TagWrapper>
           <ArticleTag

--- a/frontend/src/components/common/GroupArticleCard/index.tsx
+++ b/frontend/src/components/common/GroupArticleCard/index.tsx
@@ -31,7 +31,13 @@ const GroupArticleCard = ({ article }: Props) => {
         </DimmedBox>
       )}
       <ImageWrapper>
-        <Image src={article.thumbnail} alt={'thumbnail-image'} layout="fill" objectFit="cover" />
+        <Image
+          src={article.thumbnail}
+          alt={'thumbnail-image'}
+          layout="fill"
+          objectFit="cover"
+          sizes="400px"
+        />
       </ImageWrapper>
       <InfoWrapper>
         <TagWrapper>

--- a/frontend/src/components/common/GroupArticleCard/styles.ts
+++ b/frontend/src/components/common/GroupArticleCard/styles.ts
@@ -26,6 +26,12 @@ const DimmedBox = styled.div`
   justify-content: center;
 `;
 
+const ImageWrapper = styled.div`
+  width: 100%;
+  height: 20rem;
+  position: relative;
+`;
+
 const ClosedText = styled.div`
   color: ${({ theme }) => theme.white};
   font-size: 2rem;
@@ -58,4 +64,13 @@ const CapacityText = styled.span`
   color: ${({ theme }) => theme.colors.gray[6]};
 `;
 
-export { CardWrapper, DimmedBox, InfoWrapper, TagWrapper, TitleText, CapacityText, ClosedText };
+export {
+  CardWrapper,
+  DimmedBox,
+  ImageWrapper,
+  InfoWrapper,
+  TagWrapper,
+  TitleText,
+  CapacityText,
+  ClosedText,
+};

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -113,9 +113,9 @@ const Main = () => {
           <ListWrapper>
             {articles.map((article) => (
               <Link key={article.id} href={`/article/${article.id}`}>
-                <div key={article.id}>
+                <CardLink key={article.id}>
                   <GroupArticleCard article={article} />
-                </div>
+                </CardLink>
               </Link>
             ))}
             <div ref={ref}></div>
@@ -161,4 +161,8 @@ const ListWrapper = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-gap: 1.3rem;
+`;
+
+const CardLink = styled.div`
+  overflow: auto;
 `;


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 모집 게시글의 title이 길어질 때, grid 규격이 깨지고 카드의 너비가 넓어지는 문제를 해결하였습니다.

![title-overflow](https://user-images.githubusercontent.com/37508296/205042012-deb9fd83-5d17-4567-ab85-f11934c564d7.gif)


- 이미지 렌더링 시 `next/Image` 를 이용해 렌더링 했습니다.



## 문제 상황과 해결


## 비고

[참고 링크](https://thinkforthink.tistory.com/364)
