### PR TITLE
[BUGFIX] 이미지 url이 제대로 전달되지 않는 문제 수정

### DIFF
--- a/backend/src/app/group-article/dto/get-group-article-detail-response.dto.ts
+++ b/backend/src/app/group-article/dto/get-group-article-detail-response.dto.ts
@@ -5,7 +5,6 @@ import {
   LOCATION,
 } from '@app/group-article/constants/group-article.constants';
 import { IGroupArticleDetail } from '@app/group-article/dto/group-article-detail.interface';
-import { ImageService } from '@app/image/image.service';
 import { ApiProperty } from '@nestjs/swagger';
 import { Author } from '@app/group-article/dto/author.dto';
 
@@ -58,10 +57,7 @@ export class GetGroupArticleDetailResponse {
   @ApiProperty({ example: new Date(), description: '게시글 작성일' })
   createdAt: Date;
 
-  static from(
-    groupArticleDetail: IGroupArticleDetail,
-    imageService: ImageService,
-  ) {
+  static from(groupArticleDetail: IGroupArticleDetail) {
     const res = new GetGroupArticleDetailResponse();
     res.id = groupArticleDetail.id;
     res.title = groupArticleDetail.title;
@@ -72,9 +68,7 @@ export class GetGroupArticleDetailResponse {
       profileImage: groupArticleDetail.userProfileImage,
     };
     res.category = groupArticleDetail.groupCategoryName;
-    res.thumbnail = imageService.getStorageUrl([
-      groupArticleDetail.thumbnail,
-    ])[0];
+    res.thumbnail = groupArticleDetail.thumbnail;
     res.status = groupArticleDetail.status;
     res.location = groupArticleDetail.location;
     res.commentCount = groupArticleDetail.commentCount;

--- a/backend/src/app/group-article/dto/group-article-register-request.dto.ts
+++ b/backend/src/app/group-article/dto/group-article-register-request.dto.ts
@@ -1,5 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNumber, IsString, Length, Min } from 'class-validator';
+import {
+  IsEnum,
+  IsNumber,
+  IsString,
+  IsUrl,
+  Length,
+  Min,
+} from 'class-validator';
 import {
   CATEGORY,
   LOCATION,
@@ -52,11 +59,12 @@ export class GroupArticleRegisterRequest {
   maxCapacity: number;
 
   @ApiProperty({
-    example: '1669282011949-761671c7-cc43-4cee-bcb5-4bf3fea9478b.png',
-    description: '썸네일 이미지가 저장되어있는 주소',
+    example:
+      'https://kr.object.ncloudstorage.com/uploads/images/1669276833875-64adca9c-94cd-4162-a53f-f75e951e39db',
+    description: '썸네일 이미지가 저장되어있는 주소(url)',
     required: true,
   })
-  @IsString()
+  @IsUrl()
   thumbnail: string;
 
   @ApiProperty({

--- a/backend/src/app/group-article/dto/group-article-search-result.dto.ts
+++ b/backend/src/app/group-article/dto/group-article-search-result.dto.ts
@@ -6,7 +6,6 @@ import {
   LOCATION,
 } from '@app/group-article/constants/group-article.constants';
 import { IGroupArticleSearchResult } from '@app/group-article/dto/group-article-search-result.interface';
-import { ImageService } from '@app/image/image.service';
 
 export class GroupArticleSearchResult {
   @ApiProperty({ example: 1, description: '게시글 아이디' })
@@ -55,11 +54,11 @@ export class GroupArticleSearchResult {
   })
   createdAt: Date;
 
-  static from(row: IGroupArticleSearchResult, imageService: ImageService) {
+  static from(row: IGroupArticleSearchResult) {
     const res = new GroupArticleSearchResult();
     res.id = row.id;
     res.title = row.title;
-    res.thumbnail = imageService.getStorageUrl([row.thumbnail])[0];
+    res.thumbnail = row.thumbnail;
     res.category = row.groupCategoryName;
     res.location = row.location;
     res.status = row.status;

--- a/backend/src/app/group-article/group-article.controller.ts
+++ b/backend/src/app/group-article/group-article.controller.ts
@@ -25,7 +25,6 @@ import { GroupArticleRepository } from '@app/group-article/repository/group-arti
 import { SearchGroupArticlesRequest } from '@app/group-article/dto/search-group-articles-request.dto';
 import { SearchGroupArticleResponse } from '@app/group-article/dto/search-group-articles-response.dto';
 import { GroupArticleSearchResult } from '@app/group-article/dto/group-article-search-result.dto';
-import { ImageService } from '@app/image/image.service';
 import { CurrentUser } from '@decorator/current-user.decorator';
 import { User } from '@app/user/entity/user.entity';
 import { GetGroupArticleDetailResponse } from '@app/group-article/dto/get-group-article-detail-response.dto';
@@ -45,7 +44,6 @@ export class GroupArticleController {
     private readonly groupArticleService: GroupArticleService,
     private readonly groupCategoryRepository: GroupCategoryRepository,
     private readonly groupArticleRepository: GroupArticleRepository,
-    private readonly imageService: ImageService,
   ) {}
 
   @Post('/')
@@ -143,7 +141,7 @@ export class GroupArticleController {
     const groupArticleDetail = await this.groupArticleService.getDetailById(id);
 
     return ResponseEntity.OK_WITH_DATA(
-      GetGroupArticleDetailResponse.from(groupArticleDetail, this.imageService),
+      GetGroupArticleDetailResponse.from(groupArticleDetail),
     );
   }
 

--- a/backend/src/app/group-article/group-article.controller.ts
+++ b/backend/src/app/group-article/group-article.controller.ts
@@ -130,9 +130,7 @@ export class GroupArticleController {
         result[1],
         query.currentPage,
         query.countPerPage,
-        result[0].map((row) =>
-          GroupArticleSearchResult.from(row, this.imageService),
-        ),
+        result[0].map((row) => GroupArticleSearchResult.from(row)),
       ),
     );
   }

--- a/backend/src/app/group-article/group-article.module.ts
+++ b/backend/src/app/group-article/group-article.module.ts
@@ -4,10 +4,8 @@ import { GroupArticleService } from '@app/group-article/group-article.service';
 import { GroupCategoryRepository } from '@app/group-article/repository/group-category.repository';
 import { GroupRepository } from '@app/group-article/repository/group.repository';
 import { GroupArticleRepository } from '@app/group-article/repository/group-article.repository';
-import { ImageModule } from '@app/image/image.module';
 
 @Module({
-  imports: [ImageModule],
   controllers: [GroupArticleController],
   providers: [
     GroupArticleService,

--- a/backend/src/app/image/image.service.ts
+++ b/backend/src/app/image/image.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { S3ConfigService } from '@src/common/config/s3/config.service';
 import { Endpoint, S3 } from 'aws-sdk';
 import * as path from 'path';
@@ -6,7 +6,6 @@ import { v4 } from 'uuid';
 
 @Injectable()
 export class ImageService {
-  private readonly logger = new Logger(ImageService.name);
   private readonly s3: S3;
 
   constructor(private readonly s3ConfigService: S3ConfigService) {
@@ -72,11 +71,7 @@ export class ImageService {
 
   getStorageUrl(keyList: string[]) {
     return keyList.map((key) => {
-      return path.join(
-        this.s3ConfigService.endpoint,
-        this.s3ConfigService.bucket,
-        key,
-      );
+      return `${this.s3ConfigService.endpoint}/${this.s3ConfigService.bucket}/${key}`;
     });
   }
 }


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

### 이미지 key를 url로 변환시키는 로직 수정

- path 패키지를 사용하지 않고 `` 사용

- `https:/` 로 전달되었었는데 `https://`로 전달돼요.

![image](https://user-images.githubusercontent.com/67570061/205071842-cdf8a76c-0cdf-482a-9270-c8adca8be5f9.png)


### 모집 게시글 작성시 thumbnail을 url로 전달하도록 수정

### 모집게시글 목록조회 API에서 thumbnail을 그대로 전달하도록 수정

### 모집게시글 상세조회 API에서 thumbnail을 그대로 전달하도록 수정

### `GroupArticleModule`에서 더이상 `ImageService`를 사용하지 않아 `ImageModule` 의존성 제거

## 문제 상황과 해결

- 작업 중 마주한 문제상황 및 해결방법을 남겨주세요.

## 비고

- 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
