### PR TITLE
[BUGFIX] 게시글 썸네일 업로드시 url을 전송

### DIFF
--- a/frontend/src/pages/article/write/index.tsx
+++ b/frontend/src/pages/article/write/index.tsx
@@ -62,7 +62,7 @@ const WritePage = () => {
       const { uploadedImage, ...rest } = articleInput;
       await clientAxios.post('/v1/group-articles', {
         ...rest,
-        thumbnail: uploadedImage.key,
+        thumbnail: uploadedImage.url,
       });
       // TODO : mutation 로직 추가?
       showToast({


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 업로드 시 이미지 url을 전송하도록 수정했습니다

## 문제 상황과 해결

- 작업 중 마주한 문제상황 및 해결방법을 남겨주세요.

## 비고

- #183 
