### PR TITLE
[Feature] 내가 작성한 모집 게시글 목록 조회

### DIFF
--- a/backend/src/app/group-article/group-article.controller.ts
+++ b/backend/src/app/group-article/group-article.controller.ts
@@ -121,7 +121,13 @@ export class GroupArticleController {
   @Get('search')
   @ApiSuccessResponse(HttpStatus.OK, SearchGroupArticleResponse)
   async search(@Query() query: SearchGroupArticlesRequest) {
-    const result = await this.groupArticleRepository.search(query);
+    const result = await this.groupArticleRepository.search({
+      limit: query.getLimit(),
+      offset: query.getOffset(),
+      location: query.location,
+      category: query.category,
+      status: query.status,
+    });
 
     return ResponseEntity.OK_WITH_DATA(
       new SearchGroupArticleResponse(

--- a/backend/src/app/group-article/group-article.controller.ts
+++ b/backend/src/app/group-article/group-article.controller.ts
@@ -36,6 +36,7 @@ import { UpdateGroupArticleRequest } from '@app/group-article/dto/update-group-a
 import { NotSuccessGroupException } from '@app/group-article/exception/not-success-group.exception';
 import { NotParticipantException } from '@app/group-article/exception/not-participant.exception';
 import { GetGroupChatUrlResponseDto } from '@app/group-article/dto/get-group-chat-url-response.dto';
+import { PageRequest } from '@common/util/page-request';
 
 @Controller('group-articles')
 @ApiTags('Group-Article')
@@ -127,6 +128,29 @@ export class GroupArticleController {
       location: query.location,
       category: query.category,
       status: query.status,
+    });
+
+    return ResponseEntity.OK_WITH_DATA(
+      new SearchGroupArticleResponse(
+        result[1],
+        query.currentPage,
+        query.countPerPage,
+        result[0].map((row) => GroupArticleSearchResult.from(row)),
+      ),
+    );
+  }
+
+  @Get('me')
+  @JwtAuth()
+  @ApiSuccessResponse(HttpStatus.OK, SearchGroupArticleResponse)
+  async getMyGroupArticles(
+    @CurrentUser() user: User,
+    @Query() query: PageRequest,
+  ) {
+    const result = await this.groupArticleRepository.search({
+      limit: query.getLimit(),
+      offset: query.getOffset(),
+      user,
     });
 
     return ResponseEntity.OK_WITH_DATA(

--- a/backend/src/app/group-article/repository/group-article.repository.ts
+++ b/backend/src/app/group-article/repository/group-article.repository.ts
@@ -18,10 +18,11 @@ import {
 @Injectable()
 export class GroupArticleRepository extends Repository<GroupArticle> {
   constructor(private readonly dataSource: DataSource) {
+    const baseRepository = dataSource.getRepository(GroupArticle);
     super(
-      GroupArticle,
-      dataSource.createEntityManager(),
-      dataSource.createQueryRunner(),
+      baseRepository.target,
+      baseRepository.manager,
+      baseRepository.queryRunner,
     );
   }
 
@@ -142,5 +143,60 @@ export class GroupArticleRepository extends Repository<GroupArticle> {
       .andWhere('groupArticle.deletedAt IS NULL')
       .groupBy('groupArticle.id')
       .getRawOne<IGroupArticleDetail>();
+  }
+
+  async getsByUser({
+    limit,
+    offset,
+    user,
+  }: {
+    limit: number;
+    offset: number;
+    user: User;
+  }): Promise<[IGroupArticleSearchResult[], number]> {
+    const query = this.createQueryBuilder('groupArticle')
+      .select([
+        'groupArticle.id as id',
+        'groupArticle.title as title',
+        'groupArticle.createdAt as createdAt',
+        'group.maxCapacity as maxCapacity',
+        'group.thumbnail as thumbnail',
+        'group.status as status',
+        'group.location as location',
+        'groupCategory.id as groupCategoryId',
+        'groupCategory.name as groupCategoryName',
+        'COUNT(DISTINCT groupApplication.id) as currentCapacity',
+        'COUNT(DISTINCT scrap.id) as scrapCount',
+        'COUNT(DISTINCT comment.id) as commentCount',
+      ])
+      .leftJoin(Group, 'group', 'groupArticle.id = group.article_id')
+      .leftJoin(
+        GroupCategory,
+        'groupCategory',
+        'groupCategory.id = group.category.id AND groupCategory.deletedAt IS NULL',
+      )
+      .leftJoin(
+        GroupApplication,
+        'groupApplication',
+        'group.id = groupApplication.groupId AND groupApplication.deletedAt IS NULL',
+      )
+      .leftJoin(
+        Comment,
+        'comment',
+        'groupArticle.id = comment.articleId AND comment.deletedAt IS NULL',
+      )
+      .leftJoin(Scrap, 'scrap', 'groupArticle.id = scrap.articleId')
+      .where('groupArticle.deletedAt IS NULL')
+      .andWhere('groupArticle.userId = :userId', { userId: user.id })
+      .groupBy('groupArticle.id');
+
+    const count = await query.clone().getCount();
+    const result = await query
+      .orderBy('groupArticle.id', 'DESC')
+      .limit(limit)
+      .offset(offset)
+      .getRawMany<IGroupArticleSearchResult>();
+
+    return [result, count];
   }
 }

--- a/backend/src/common/config/database/typeorm/config.service.ts
+++ b/backend/src/common/config/database/typeorm/config.service.ts
@@ -9,12 +9,10 @@ import { AppConfigService } from '@config/app/config.service';
 export class TypeOrmConfigService implements TypeOrmOptionsFactory {
   constructor(
     private readonly mysqlConfigService: MysqlConfigService,
-    private readonly appConfigServce: AppConfigService,
+    private readonly appConfigService: AppConfigService,
   ) {}
 
-  createTypeOrmOptions(
-    connectionName?: string,
-  ): Promise<TypeOrmModuleOptions> | TypeOrmModuleOptions {
+  createTypeOrmOptions(): Promise<TypeOrmModuleOptions> | TypeOrmModuleOptions {
     const entityPath = path.resolve(
       __dirname,
       '../../../../**/*.entity.{js,ts}',
@@ -22,16 +20,17 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
 
     return {
       type: 'mysql',
-      name: connectionName,
       host: this.mysqlConfigService.hostname,
       username: this.mysqlConfigService.username,
       password: this.mysqlConfigService.password,
       database: this.mysqlConfigService.database,
       port: this.mysqlConfigService.port,
-      synchronize: !this.appConfigServce.isPrduction(),
-      logging: this.appConfigServce.isDevelopment() ? 'all' : ['error', 'warn'],
+      synchronize: !this.appConfigService.isPrduction(),
+      logging: this.appConfigService.isDevelopment()
+        ? 'all'
+        : ['error', 'warn'],
       entities: [entityPath],
-      dropSchema: this.appConfigServce.isTest(),
+      dropSchema: this.appConfigService.isTest(),
       namingStrategy: new SnakeNamingStrategy(),
       timezone: 'Z',
       poolSize: 50,


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

### `GET /v1/group-articles/me` 내가 작성한 모집 게시글 목록 조회 API 추가

- 내가 작성한 모집 게시글만 조회되는 API 추가

## 문제 상황과 해결

### 기존에 있던 검색 쿼리 메소드와 분리해야할까?

내가 작성한 모집게시글 목록조회를 위해 기존에 있던 모집게시글 목록 조회 API와 상당히 유사한 쿼리가 필요했다. 내가 작성한 모집게시글 목록페이지에는 필터링이 없고 단순히 페이지네이션만 적용된 데이터가 필요했다. 하지만 모집게시글정보에서 필요한 데이터는 같았다. 

서로 변경되는 시점이 다를 수 있을 것 같아 분리해야할까 라는 생각이 들긴하지만 우선은 하나로 합쳐놓은 상태입니다!

### 오랜시간이 작동하지 않는 경우 디비와 커넥션 끊기는 문제 및 핸들링이 안되는 문제

TypeOrm 0.2.x버전에서 0.3.x 버전으로 올라오면서 NestJS에서 TypeOrm Repository Pattern을 사용하기 위한 방법이 달라졌어요! 근데 올바르지 않은 방법으로 사용해서 생긴 문제같아요. 우선 예상되는 지점의 코드를 아래와 같이 변경해보니 로컬에서는 해결되는것 같아 올렸습니다.

https://github.com/boostcampwm-2022/web13-moyeomoyeo/blob/d5d26d5d07d30bcfc2a6f3d43d06cb66091e8955/backend/src/app/group-article/repository/group-article.repository.ts#L20-L27

정상적으로 해결된다면, 다른 repository들 유사하게 코드를 변경하거나 https://velog.io/@username1103/NestJS-TypeORM 에서 제공하는 방법2 또는 방법3 같은 방식으로 변경하면 좋을 것 같아요.

## 비고

- 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
