### PR TITLE
[Feature] 내가 작성한 모임 게시글 조회 API 추가

### DIFF
--- a/backend/src/app/group-article/dto/get-group-article-detail-response.dto.ts
+++ b/backend/src/app/group-article/dto/get-group-article-detail-response.dto.ts
@@ -19,7 +19,7 @@ export class GetGroupArticleDetailResponse {
     example: `안녕하세요. 서울 지역 CS 스터디원들을 모집합니다!\\n<img width="1440" alt="서울 지역 CS 모집 사진자료" src="https://kr.object.ncloudstorage.com/moyeo-images/uploads/images/1669282011949-761671c7-cc43-4cee-bcb5-4bf3fea9478b.png">`,
     description: '게시글 제목',
   })
-  content: string;
+  contents: string;
 
   @ApiProperty()
   author: Author;
@@ -61,7 +61,7 @@ export class GetGroupArticleDetailResponse {
     const res = new GetGroupArticleDetailResponse();
     res.id = groupArticleDetail.id;
     res.title = groupArticleDetail.title;
-    res.content = groupArticleDetail.contents;
+    res.contents = groupArticleDetail.contents;
     res.author = {
       id: groupArticleDetail.userId,
       userName: groupArticleDetail.userName,

--- a/backend/src/app/group-article/dto/get-my-group-article-response.dto.ts
+++ b/backend/src/app/group-article/dto/get-my-group-article-response.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  CATEGORY,
+  GROUP_STATUS,
+  LOCATION,
+} from '@app/group-article/constants/group-article.constants';
+import { GroupArticle } from '@app/group-article/entity/group-article.entity';
+
+export class GetMyGroupArticleResponse {
+  @ApiProperty({ example: 1, description: '게시글 아이디' })
+  id: number;
+
+  @ApiProperty({ example: 'CS 스터디 모집', description: '게시글 제목' })
+  title: string;
+
+  @ApiProperty({
+    example: `안녕하세요. 서울 지역 CS 스터디원들을 모집합니다!\\n<img width="1440" alt="서울 지역 CS 모집 사진자료" src="https://kr.object.ncloudstorage.com/moyeo-images/uploads/images/1669282011949-761671c7-cc43-4cee-bcb5-4bf3fea9478b.png">`,
+    description: '게시글 제목',
+  })
+  content: string;
+
+  @ApiProperty({ example: CATEGORY.STUDY, description: '모집 카테고리' })
+  category: string;
+
+  @ApiProperty({ example: LOCATION.ONLINE, description: '모임 장소' })
+  location: LOCATION;
+
+  @ApiProperty({
+    example:
+      'https://kr.object.ncloudstorage.com/uploads/images/1669276833875-64adca9c-94cd-4162-a53f-f75e951e39db',
+    description: '게시글 썸네일',
+  })
+  thumbnail: string;
+
+  @ApiProperty({
+    example: GROUP_STATUS.PROGRESS,
+    description: '모집 게시글 상태',
+  })
+  status: GROUP_STATUS;
+
+  @ApiProperty({ example: 10, description: '최대 모집 인원' })
+  maxCapacity: number;
+
+  @ApiProperty({
+    example: 'https://open.kakao.com/오픈채팅방path',
+    description: '카카오톡과 기타 채팅서비스의 주소를 담아놓을 수 있다.',
+  })
+  url: string;
+
+  @ApiProperty({ example: new Date(), description: '게시글 작성일' })
+  createdAt: Date;
+
+  static from(groupArticle: GroupArticle) {
+    const res = new GetMyGroupArticleResponse();
+    res.id = groupArticle.id;
+    res.title = groupArticle.title;
+    res.content = groupArticle.contents;
+
+    res.category = groupArticle.group.category.name;
+    res.thumbnail = groupArticle.group.thumbnail;
+    res.status = groupArticle.group.status;
+    res.location = groupArticle.group.location;
+    res.maxCapacity = groupArticle.group.maxCapacity;
+    res.url = groupArticle.group.chatUrl;
+    res.createdAt = groupArticle.group.createdAt;
+    return res;
+  }
+}

--- a/backend/src/app/group-article/dto/get-my-group-article-response.dto.ts
+++ b/backend/src/app/group-article/dto/get-my-group-article-response.dto.ts
@@ -17,7 +17,7 @@ export class GetMyGroupArticleResponse {
     example: `안녕하세요. 서울 지역 CS 스터디원들을 모집합니다!\\n<img width="1440" alt="서울 지역 CS 모집 사진자료" src="https://kr.object.ncloudstorage.com/moyeo-images/uploads/images/1669282011949-761671c7-cc43-4cee-bcb5-4bf3fea9478b.png">`,
     description: '게시글 제목',
   })
-  content: string;
+  contents: string;
 
   @ApiProperty({ example: CATEGORY.STUDY, description: '모집 카테고리' })
   category: string;
@@ -54,8 +54,7 @@ export class GetMyGroupArticleResponse {
     const res = new GetMyGroupArticleResponse();
     res.id = groupArticle.id;
     res.title = groupArticle.title;
-    res.content = groupArticle.contents;
-
+    res.contents = groupArticle.contents;
     res.category = groupArticle.group.category.name;
     res.thumbnail = groupArticle.group.thumbnail;
     res.status = groupArticle.group.status;

--- a/backend/src/app/group-article/dto/group-article-register-request.dto.ts
+++ b/backend/src/app/group-article/dto/group-article-register-request.dto.ts
@@ -5,6 +5,7 @@ import {
   IsString,
   IsUrl,
   Length,
+  Max,
   Min,
 } from 'class-validator';
 import {
@@ -56,6 +57,7 @@ export class GroupArticleRegisterRequest {
   })
   @IsNumber()
   @Min(2)
+  @Max(15)
   maxCapacity: number;
 
   @ApiProperty({

--- a/backend/src/app/group-article/group-article.module.ts
+++ b/backend/src/app/group-article/group-article.module.ts
@@ -4,9 +4,10 @@ import { GroupArticleService } from '@app/group-article/group-article.service';
 import { GroupCategoryRepository } from '@app/group-article/repository/group-category.repository';
 import { GroupRepository } from '@app/group-article/repository/group.repository';
 import { GroupArticleRepository } from '@app/group-article/repository/group-article.repository';
+import { MyGroupArticleController } from '@app/group-article/my-group-article.controller';
 
 @Module({
-  controllers: [GroupArticleController],
+  controllers: [GroupArticleController, MyGroupArticleController],
   providers: [
     GroupArticleService,
     GroupRepository,

--- a/backend/src/app/group-article/group-article.module.ts
+++ b/backend/src/app/group-article/group-article.module.ts
@@ -5,6 +5,7 @@ import { GroupCategoryRepository } from '@app/group-article/repository/group-cat
 import { GroupRepository } from '@app/group-article/repository/group.repository';
 import { GroupArticleRepository } from '@app/group-article/repository/group-article.repository';
 import { MyGroupArticleController } from '@app/group-article/my-group-article.controller';
+import { MyGroupArticleService } from '@app/group-article/my-group-article.service';
 
 @Module({
   controllers: [GroupArticleController, MyGroupArticleController],
@@ -13,6 +14,7 @@ import { MyGroupArticleController } from '@app/group-article/my-group-article.co
     GroupRepository,
     GroupCategoryRepository,
     GroupArticleRepository,
+    MyGroupArticleService,
   ],
   exports: [GroupArticleRepository],
 })

--- a/backend/src/app/group-article/my-group-article.controller.ts
+++ b/backend/src/app/group-article/my-group-article.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Query,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { GroupArticleRepository } from '@app/group-article/repository/group-article.repository';
 import { JwtAuth } from '@decorator/jwt-auth.decorator';
@@ -9,12 +16,18 @@ import { User } from '@app/user/entity/user.entity';
 import { PageRequest } from '@common/util/page-request';
 import { ResponseEntity } from '@common/response-entity';
 import { GroupArticleSearchResult } from '@app/group-article/dto/group-article-search-result.dto';
+import { ApiErrorResponse } from '@decorator/api-error-response.decorator';
+import { GroupArticleNotFoundException } from '@app/group-article/exception/group-article-not-found.exception';
+import { NotAuthorException } from '@app/group-article/exception/not-author.exception';
+import { MyGroupArticleService } from '@app/group-article/my-group-article.service';
+import { GetMyGroupArticleResponse } from '@app/group-article/dto/get-my-group-article-response.dto';
 
 @Controller('my-group-articles')
 @ApiTags('MyGroupArticle')
 export class MyGroupArticleController {
   constructor(
     private readonly groupArticleRepository: GroupArticleRepository,
+    private readonly myGroupArticleService: MyGroupArticleService,
   ) {}
 
   @Get('/')
@@ -37,6 +50,21 @@ export class MyGroupArticleController {
         query.countPerPage,
         result[0].map((row) => GroupArticleSearchResult.from(row)),
       ),
+    );
+  }
+
+  @Get(':id')
+  @JwtAuth()
+  @ApiSuccessResponse(HttpStatus.OK, GetMyGroupArticleResponse)
+  @ApiErrorResponse(GroupArticleNotFoundException, NotAuthorException)
+  async getMyGroupArticle(
+    @CurrentUser() user: User,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    const groupArticle = await this.myGroupArticleService.getById(user, id);
+
+    return ResponseEntity.OK_WITH_DATA(
+      GetMyGroupArticleResponse.from(groupArticle),
     );
   }
 }

--- a/backend/src/app/group-article/my-group-article.controller.ts
+++ b/backend/src/app/group-article/my-group-article.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { GroupArticleRepository } from '@app/group-article/repository/group-article.repository';
+import { JwtAuth } from '@decorator/jwt-auth.decorator';
+import { ApiSuccessResponse } from '@decorator/api-success-resposne.decorator';
+import { SearchGroupArticleResponse } from '@app/group-article/dto/search-group-articles-response.dto';
+import { CurrentUser } from '@decorator/current-user.decorator';
+import { User } from '@app/user/entity/user.entity';
+import { PageRequest } from '@common/util/page-request';
+import { ResponseEntity } from '@common/response-entity';
+import { GroupArticleSearchResult } from '@app/group-article/dto/group-article-search-result.dto';
+
+@Controller('my-group-articles')
+@ApiTags('MyGroupArticle')
+export class MyGroupArticleController {
+  constructor(
+    private readonly groupArticleRepository: GroupArticleRepository,
+  ) {}
+
+  @Get('/')
+  @JwtAuth()
+  @ApiSuccessResponse(HttpStatus.OK, SearchGroupArticleResponse)
+  async getMyGroupArticles(
+    @CurrentUser() user: User,
+    @Query() query: PageRequest,
+  ) {
+    const result = await this.groupArticleRepository.search({
+      limit: query.getLimit(),
+      offset: query.getOffset(),
+      user,
+    });
+
+    return ResponseEntity.OK_WITH_DATA(
+      new SearchGroupArticleResponse(
+        result[1],
+        query.currentPage,
+        query.countPerPage,
+        result[0].map((row) => GroupArticleSearchResult.from(row)),
+      ),
+    );
+  }
+}

--- a/backend/src/app/group-article/my-group-article.service.ts
+++ b/backend/src/app/group-article/my-group-article.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { GroupArticleRepository } from '@app/group-article/repository/group-article.repository';
+import { User } from '@app/user/entity/user.entity';
+import { GroupArticleNotFoundException } from '@app/group-article/exception/group-article-not-found.exception';
+import { NotAuthorException } from '@app/group-article/exception/not-author.exception';
+
+@Injectable()
+export class MyGroupArticleService {
+  constructor(
+    private readonly groupArticleRepository: GroupArticleRepository,
+  ) {}
+
+  async getById(user: User, id: number) {
+    const groupArticle = await this.groupArticleRepository.findById(id);
+    if (!groupArticle) {
+      throw new GroupArticleNotFoundException();
+    }
+
+    if (!groupArticle.isAuthor(user)) {
+      throw new NotAuthorException();
+    }
+
+    return groupArticle;
+  }
+}


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

### `GET /v1/group-articles/me` -> `GET /v1/my-group-artices` 로 수정

- 훨씬 가독성있는 선택이라고 생각해 수정

### `GET /v1/my-group-articles/:id` 내가 작성한 게시글 조회 API 추가

- 내가 작성한 게시글을 조회할 때는 private한 정보(ex. 오픈채팅방url)를 전달해주어야 하기 때문에 별도 API를 제작했습니다.

### 모집 게시글 작성시 최대 인원수 15명 제한 추가

- 자꾸 사람들이 모집게시글 작성 최대인원수로 능욕해서 추가했어요.

<img width="493" alt="image" src="https://user-images.githubusercontent.com/67570061/205679366-46324413-5002-49d1-84aa-7c6e6c69a238.png">


## 문제 상황과 해결

- 작업 중 마주한 문제상황 및 해결방법을 남겨주세요.

## 비고

- 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
