### PR TITLE
[BUGFIX] 헤더상단 드랍다운 버그 해결

### DIFF
--- a/frontend/src/components/common/Avatar/index.tsx
+++ b/frontend/src/components/common/Avatar/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, ForwardedRef, forwardRef } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -15,17 +15,23 @@ interface Props extends ComponentProps<typeof Image> {
   size: keyof typeof AVATAR_SIZES;
 }
 
-const Avatar = ({ size, ...rest }: Props) => {
-  return (
-    <AvatarImage
-      {...rest}
-      layout="fixed"
-      width={AVATAR_SIZES[size]}
-      height={AVATAR_SIZES[size]}
-      defaultImgUrl="/avatar.jpg"
-    />
-  );
-};
+const Avatar = forwardRef<HTMLDivElement, Props>(
+  ({ size, ...rest }: Props, ref: ForwardedRef<HTMLDivElement>) => {
+    return (
+      <div ref={ref}>
+        <AvatarImage
+          {...rest}
+          layout="fixed"
+          width={AVATAR_SIZES[size]}
+          height={AVATAR_SIZES[size]}
+          defaultImgUrl="/avatar.jpg"
+        />
+      </div>
+    );
+  }
+);
+
+Avatar.displayName = 'Avatar';
 
 const AvatarImage = styled(Image)`
   border-radius: 50%;

--- a/frontend/src/components/common/Avatar/index.tsx
+++ b/frontend/src/components/common/Avatar/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, ForwardedRef, forwardRef } from 'react';
+import { ComponentProps, forwardRef } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -15,21 +15,19 @@ interface Props extends ComponentProps<typeof Image> {
   size: keyof typeof AVATAR_SIZES;
 }
 
-const Avatar = forwardRef<HTMLDivElement, Props>(
-  ({ size, ...rest }: Props, ref: ForwardedRef<HTMLDivElement>) => {
-    return (
-      <div ref={ref}>
-        <AvatarImage
-          {...rest}
-          layout="fixed"
-          width={AVATAR_SIZES[size]}
-          height={AVATAR_SIZES[size]}
-          defaultImgUrl="/avatar.jpg"
-        />
-      </div>
-    );
-  }
-);
+const Avatar = forwardRef<HTMLDivElement, Props>(({ size, ...rest }, ref) => {
+  return (
+    <div ref={ref}>
+      <AvatarImage
+        {...rest}
+        layout="fixed"
+        width={AVATAR_SIZES[size]}
+        height={AVATAR_SIZES[size]}
+        defaultImgUrl="/avatar.jpg"
+      />
+    </div>
+  );
+});
 
 Avatar.displayName = 'Avatar';
 


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- Avatar에서 ref를 전달받도록 수정했습니다.
  - `Image`가 바로 ref를 받도록 해도 되지만, `next/Image`는 ref를 따로 받지 않도록 설계가 되어있어서 `div` 태그가 대신해서 Ref를 넘겨받도록 수정했습니다.
  - ref를 넘겨주는 것은 React의 `forwardRef`를 이용했습니다.

```tsx
const Avatar = forwardRef<HTMLDivElement, Props>(({ size, ...rest }, ref) => {
  return (
    <div ref={ref}>
      <AvatarImage
        {...rest}
        layout="fixed"
        width={AVATAR_SIZES[size]}
        height={AVATAR_SIZES[size]}
        defaultImgUrl="/avatar.jpg"
      />
    </div>
  );
});
```

## 문제 상황과 해결


## 비고

[forwardRef 전달하기](https://dev.to/jexperton/ref-forwarding-with-react-function-components-and-typescript-20ip)
