### PR TITLE
[Feature] GroupArticle 썸네일에 blur 처리

### DIFF
--- a/frontend/src/components/common/GroupArticleCard/index.tsx
+++ b/frontend/src/components/common/GroupArticleCard/index.tsx
@@ -22,42 +22,47 @@ interface Props {
 }
 
 const GroupArticleCard = ({ article }: Props) => {
+  const {
+    status,
+    thumbnail: { originUrl, blurUrl },
+
+    category,
+    location,
+    title,
+    maxCapacity,
+    currentCapacity,
+    commentCount,
+  } = article;
   return (
     <CardWrapper>
-      {article.status !== ArticleStatus.PROGRESS && (
+      {status !== ArticleStatus.PROGRESS && (
         <DimmedBox>
           <ClosedText>모집 종료</ClosedText>
         </DimmedBox>
       )}
       <ImageWrapper>
         <Image
-          src={article.thumbnail.originUrl}
+          src={originUrl}
           alt={'thumbnail-image'}
           layout="fill"
           objectFit="cover"
           sizes="400px"
+          placeholder="blur"
+          blurDataURL={blurUrl}
+          style={{ transition: '0.3s ease-in-out' }}
         />
       </ImageWrapper>
       <InfoWrapper>
         <TagWrapper>
-          <ArticleTag
-            color={STATUS_COLOR[article.status]}
-            content={ArticleStatusKr[article.status]}
-          />
-          <ArticleTag
-            color={CATEGORY_COLOR[article.category]}
-            content={CategoryKr[article.category]}
-          />
-          <ArticleTag
-            color={LOCATION_COLOR[article.location]}
-            content={LocationKr[article.location]}
-          />
+          <ArticleTag color={STATUS_COLOR[status]} content={ArticleStatusKr[status]} />
+          <ArticleTag color={CATEGORY_COLOR[category]} content={CategoryKr[category]} />
+          <ArticleTag color={LOCATION_COLOR[location]} content={LocationKr[location]} />
         </TagWrapper>
-        <TitleText>{article.title}</TitleText>
+        <TitleText>{title}</TitleText>
         <CapacityText>
-          {article.maxCapacity}명 중 {article.currentCapacity}명 참여중
+          {maxCapacity}명 중 {currentCapacity}명 참여중
         </CapacityText>
-        <StatCounter variant="comment" count={article.commentCount} />
+        <StatCounter variant="comment" count={commentCount} />
       </InfoWrapper>
     </CardWrapper>
   );

--- a/frontend/src/hooks/queries/useFetchGroupArticles.ts
+++ b/frontend/src/hooks/queries/useFetchGroupArticles.ts
@@ -29,7 +29,7 @@ const getGroupArticles = async (
   const {
     data: { data },
   } = await clientAxios<ArticleResponseType>('/v1/group-articles/search', {
-    params: { category, location, status, currentPage, countPerPage: 5 },
+    params: { category, location, status, currentPage, countPerPage: 6 },
   });
   return data;
 };


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- GroupArticle 썸네일 이미지에 blur효과를 적용하여 로드하도록 처리하였습니다.
  ![blur](https://user-images.githubusercontent.com/38908080/206097221-a832e317-ab9e-4c68-8ddc-80440adfca79.gif)

  

## 문제 상황과 해결


## 비고