### PR TITLE
[Feature] 댓글 추가, 삭제, 조회 로직

### DIFF
--- a/frontend/src/components/article/Comment/Comment.stories.tsx
+++ b/frontend/src/components/article/Comment/Comment.stories.tsx
@@ -7,6 +7,19 @@ export default {
   component: Comment,
 } as ComponentMeta<typeof Comment>;
 
+const mockComment = {
+  id: 1,
+  authorId: 2,
+  authorName: 'J999_김캠퍼',
+  authorProfileImage: 'https://avatars.githubusercontent.com/u/90585081?v=4"',
+  contents:
+    '좋은 글 잘 읽었습니다!좋은 글 잘 읽었습니다좋은 글 잘 읽었습니다좋은 글 잘 읽었습니다좋은 글 잘 읽었습니다',
+  createdAt: '2022-11-23T08:19:33.899Z',
+};
+
 const Template: ComponentStory<typeof Comment> = (args) => <Comment {...args} />;
 
 export const Default = Template.bind({});
+Default.args = {
+  comment: mockComment,
+};

--- a/frontend/src/components/article/Comment/index.tsx
+++ b/frontend/src/components/article/Comment/index.tsx
@@ -1,7 +1,7 @@
 import { Text } from '@mantine/core';
 
 import Avatar from '@components/common/Avatar';
-import { CommentType as CommentItem } from '@typings/types';
+import { CommentType } from '@typings/types';
 import dateTimeFormat from '@utils/dateTime';
 
 import {
@@ -13,27 +13,14 @@ import {
   CommentWrapper,
 } from './styles';
 
-/**
- * mockComment 지우면 props의 optional 지우기
- */
-const mockComment = {
-  id: 1,
-  authorId: 2,
-  authorName: 'J999_김캠퍼',
-  authorProfileImage: 'https://avatars.githubusercontent.com/u/90585081?v=4"',
-  contents:
-    '좋은 글 잘 읽었습니다!좋은 글 잘 읽었습니다좋은 글 잘 읽었습니다좋은 글 잘 읽었습니다좋은 글 잘 읽었습니다',
-  createdAt: '2022-11-23T08:19:33.899Z',
-};
-
 interface Props {
   /**
    * 댓글 정보를 입력합니다.
    */
-  comment?: CommentItem;
+  comment: CommentType;
 }
 
-const Comment = ({ comment = mockComment }: Props) => {
+const Comment = ({ comment }: Props) => {
   return (
     <CommentWrapper>
       <CommentHeader>

--- a/frontend/src/components/article/Comment/index.tsx
+++ b/frontend/src/components/article/Comment/index.tsx
@@ -35,10 +35,6 @@ const Comment = ({ comment }: Props) => {
   const { data: myData } = useFetchMyInfo();
   const { mutate: deleteComment } = useDeleteComment(articleId);
 
-  const handleDeleteComment = () => {
-    deleteComment(commentId);
-  };
-
   return (
     <>
       <CommentWrapper>
@@ -73,7 +69,7 @@ const Comment = ({ comment }: Props) => {
       <ConfirmModal
         message="댓글을 삭제하시겠습니까?"
         open={confirmModalOpen}
-        onConfirmButtonClick={handleDeleteComment}
+        onConfirmButtonClick={() => deleteComment(commentId)}
         onCancelButtonClick={() => setConfirmModalOpen(false)}
       />
     </>

--- a/frontend/src/components/article/Comment/index.tsx
+++ b/frontend/src/components/article/Comment/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
@@ -42,17 +43,19 @@ const Comment = ({ comment }: Props) => {
     <>
       <CommentWrapper>
         <CommentHeader>
-          <CommentAuthor>
-            <Avatar size="sm" src={authorProfileImage} alt={authorName} />
-            <Text fz="md" fw={500}>
-              {authorName}
-            </Text>
-            <Text fz="sm" fw={300} c="gray.4">
-              {dateTimeFormat(createdAt)}
-            </Text>
-          </CommentAuthor>
+          <Link href={`/user/${authorId}`}>
+            <CommentAuthor>
+              <Avatar size="sm" src={authorProfileImage} alt={authorName} />
+              <Text fz="md" fw={500}>
+                {authorName}
+              </Text>
+              <Text fz="sm" fw={300} c="gray.4">
+                {dateTimeFormat(createdAt)}
+              </Text>
+            </CommentAuthor>
+          </Link>
           <CommentUtils>
-            {myData.id === authorId && (
+            {myData?.id === authorId && (
               <CommentUtilItem onClick={() => setConfirmModalOpen(true)}>
                 <Text fz="sm" fw={500} c="gray.4">
                   삭제

--- a/frontend/src/components/article/Comment/index.tsx
+++ b/frontend/src/components/article/Comment/index.tsx
@@ -1,6 +1,12 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
 import { Text } from '@mantine/core';
 
 import Avatar from '@components/common/Avatar';
+import ConfirmModal from '@components/common/ConfirmModal';
+import useDeleteComment from '@hooks/queries/useDeleteComment';
+import useFetchMyInfo from '@hooks/queries/useFetchMyInfo';
 import { CommentType } from '@typings/types';
 import dateTimeFormat from '@utils/dateTime';
 
@@ -21,32 +27,53 @@ interface Props {
 }
 
 const Comment = ({ comment }: Props) => {
+  const router = useRouter();
+  const articleId = Number(router.query.id);
+  const [confirmModalOpen, setConfirmModalOpen] = useState(false);
+  const { id: commentId, authorId, authorName, authorProfileImage, createdAt, contents } = comment;
+  const { data: myData } = useFetchMyInfo();
+  const { mutate: deleteComment } = useDeleteComment(articleId);
+
+  const handleDeleteComment = () => {
+    deleteComment(commentId);
+  };
+
   return (
-    <CommentWrapper>
-      <CommentHeader>
-        <CommentAuthor>
-          <Avatar size="sm" src={comment.authorProfileImage} alt={comment.authorName} />
-          <Text fz="md" fw={500}>
-            {comment.authorName}
-          </Text>
-          <Text fz="sm" fw={300} c="gray.4">
-            {dateTimeFormat(comment.createdAt)}
-          </Text>
-        </CommentAuthor>
-        <CommentUtils>
-          <CommentUtilItem onClick={() => alert('삭제 하실?')}>
-            <Text fz="sm" fw={500} c="gray.4">
-              삭제
+    <>
+      <CommentWrapper>
+        <CommentHeader>
+          <CommentAuthor>
+            <Avatar size="sm" src={authorProfileImage} alt={authorName} />
+            <Text fz="md" fw={500}>
+              {authorName}
             </Text>
-          </CommentUtilItem>
-        </CommentUtils>
-      </CommentHeader>
-      <CommentContent>
-        <Text fz="lg" fw={500}>
-          {comment.contents}
-        </Text>
-      </CommentContent>
-    </CommentWrapper>
+            <Text fz="sm" fw={300} c="gray.4">
+              {dateTimeFormat(createdAt)}
+            </Text>
+          </CommentAuthor>
+          <CommentUtils>
+            {myData.id === authorId && (
+              <CommentUtilItem onClick={() => setConfirmModalOpen(true)}>
+                <Text fz="sm" fw={500} c="gray.4">
+                  삭제
+                </Text>
+              </CommentUtilItem>
+            )}
+          </CommentUtils>
+        </CommentHeader>
+        <CommentContent>
+          <Text fz="lg" fw={500}>
+            {contents}
+          </Text>
+        </CommentContent>
+      </CommentWrapper>
+      <ConfirmModal
+        message="댓글을 삭제하시겠습니까?"
+        open={confirmModalOpen}
+        onConfirmButtonClick={handleDeleteComment}
+        onCancelButtonClick={() => setConfirmModalOpen(false)}
+      />
+    </>
   );
 };
 

--- a/frontend/src/components/article/Comment/styles.tsx
+++ b/frontend/src/components/article/Comment/styles.tsx
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 const CommentWrapper = styled.div`
   width: 100%;
   padding: 1.6rem;
-  border-top: 1px solid ${({ theme }) => theme.colors.gray[2]};
-  border-bottom: 1px solid ${({ theme }) => theme.colors.gray[2]};
   display: flex;
   flex-direction: column;
 `;

--- a/frontend/src/components/article/Comment/styles.tsx
+++ b/frontend/src/components/article/Comment/styles.tsx
@@ -18,6 +18,7 @@ const CommentAuthor = styled.div`
   display: flex;
   align-items: center;
   gap: 0.8rem;
+  cursor: pointer;
 `;
 
 const CommentUtils = styled.div`

--- a/frontend/src/components/article/CommentInput/index.tsx
+++ b/frontend/src/components/article/CommentInput/index.tsx
@@ -21,7 +21,7 @@ const CommentInput = () => {
     if (inputRef.current && inputRef.current.value.trim().length > 0) {
       addComment({ contents: inputRef.current.value, articleId });
       inputRef.current.value = '';
-      setTimeout(() => window.scrollTo(0, document.body.scrollHeight), 0);
+      setTimeout(() => window.scrollTo(0, document.body.scrollHeight), 200);
     }
   };
 

--- a/frontend/src/components/article/CommentInput/index.tsx
+++ b/frontend/src/components/article/CommentInput/index.tsx
@@ -1,21 +1,45 @@
-import { useRef } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect, useRef } from 'react';
 
 import { ActionIcon, TextInput } from '@mantine/core';
 import { IconSend } from '@tabler/icons';
 
+import useAddComment from '@hooks/queries/useAddComment';
+
 import { CommentInputWrapper } from './styles';
 
 const CommentInput = () => {
+  const {
+    query: { id },
+  } = useRouter();
+
+  const articleId = Number(id);
   const inputRef = useRef<HTMLInputElement>(null);
-  /**
-   * TODO : 댓글 입력 핸들러 수정
-   */
-  const handleSubmitComment = () => {
-    alert('댓글 입력');
-    if (inputRef.current) {
+  const { mutate: addComment } = useAddComment(articleId);
+
+  const handleAddComment = () => {
+    if (inputRef.current && inputRef.current.value.trim().length > 0) {
+      addComment({ contents: inputRef.current.value, articleId });
       inputRef.current.value = '';
+      setTimeout(() => window.scrollTo(0, document.body.scrollHeight), 0);
     }
   };
+
+  const handlePressEnter = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleAddComment();
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keypress', handlePressEnter);
+
+    return () => {
+      window.removeEventListener('keypress', handlePressEnter);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <CommentInputWrapper>
       <TextInput
@@ -23,7 +47,7 @@ const CommentInput = () => {
         placeholder="댓글을 입력해주세요."
         ref={inputRef}
         rightSection={
-          <ActionIcon variant="transparent" color="indigo" onClick={handleSubmitComment}>
+          <ActionIcon variant="transparent" color="indigo" onClick={handleAddComment}>
             <IconSend size={24} />
           </ActionIcon>
         }

--- a/frontend/src/components/article/CommentInput/index.tsx
+++ b/frontend/src/components/article/CommentInput/index.tsx
@@ -19,7 +19,7 @@ const CommentInput = () => {
   return (
     <CommentInputWrapper>
       <TextInput
-        size="lg"
+        size="md"
         placeholder="댓글을 입력해주세요."
         ref={inputRef}
         rightSection={

--- a/frontend/src/components/article/CommentInput/styles.tsx
+++ b/frontend/src/components/article/CommentInput/styles.tsx
@@ -5,6 +5,8 @@ const CommentInputWrapper = styled.div`
   width: 100%;
   position: sticky;
   bottom: 0;
+  background-color: ${({ theme }) => theme.white};
+  border-top: 1px solid ${({ theme }) => theme.colors.gray[2]};
 `;
 
 export { CommentInputWrapper };

--- a/frontend/src/components/common/Avatar/index.tsx
+++ b/frontend/src/components/common/Avatar/index.tsx
@@ -17,7 +17,7 @@ interface Props extends ComponentProps<typeof Image> {
 
 const Avatar = forwardRef<HTMLDivElement, Props>(({ size, ...rest }, ref) => {
   return (
-    <div ref={ref}>
+    <AvatarWrapper ref={ref}>
       <AvatarImage
         {...rest}
         layout="fixed"
@@ -25,11 +25,15 @@ const Avatar = forwardRef<HTMLDivElement, Props>(({ size, ...rest }, ref) => {
         height={AVATAR_SIZES[size]}
         defaultImgUrl="/avatar.jpg"
       />
-    </div>
+    </AvatarWrapper>
   );
 });
 
 Avatar.displayName = 'Avatar';
+
+const AvatarWrapper = styled.div`
+  font-size: 0;
+`;
 
 const AvatarImage = styled(Image)`
   border-radius: 50%;

--- a/frontend/src/components/common/FloatingButton/index.tsx
+++ b/frontend/src/components/common/FloatingButton/index.tsx
@@ -21,7 +21,7 @@ const FloatingButton = ({ children }: Props) => {
   const ref = useClickOutside(() => setOpened(false));
 
   return (
-    <Menu position="top-end" transition="rotate-right" transitionDuration={200}>
+    <Menu position="top-end">
       <Menu.Target>
         <FABWrapper
           color="indigo"

--- a/frontend/src/components/common/Header/UserLoginItem/index.tsx
+++ b/frontend/src/components/common/Header/UserLoginItem/index.tsx
@@ -17,7 +17,7 @@ const UserLoginItem = () => {
   if (isLoading) return null;
 
   return myData ? (
-    <Menu position="bottom-end" transition="rotate-right" transitionDuration={200}>
+    <Menu position="bottom-end">
       <Menu.Target>
         <Avatar size="md" alt={myData.userName} src={myData.profileImage} />
       </Menu.Target>

--- a/frontend/src/components/common/Header/UserLoginItem/index.tsx
+++ b/frontend/src/components/common/Header/UserLoginItem/index.tsx
@@ -19,7 +19,13 @@ const UserLoginItem = () => {
   return myData ? (
     <Menu position="bottom-end">
       <Menu.Target>
-        <Avatar size="md" alt={myData.userName} src={myData.profileImage} />
+        <Avatar
+          size="md"
+          alt={myData.userName}
+          src={myData.profileImage}
+          style={{ cursor: 'pointer' }}
+          priority
+        />
       </Menu.Target>
       <Menu.Dropdown>
         <Link href="/my">

--- a/frontend/src/components/common/Profile/index.tsx
+++ b/frontend/src/components/common/Profile/index.tsx
@@ -18,7 +18,7 @@ const Profile = ({ user }: Props) => {
 
   return (
     <ProfileWrapper>
-      <Avatar alt={user.userName} src={profileImage} size="xl" />
+      <Avatar alt={user.userName} src={profileImage} size="xl" priority />
       <UserWrapper>
         <UserName>{userName}</UserName>
         <Description>{description}</Description>

--- a/frontend/src/hooks/queries/useAddComment.ts
+++ b/frontend/src/hooks/queries/useAddComment.ts
@@ -1,0 +1,22 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import useAuthMutation from '@hooks/useAuthMutation';
+import { CommentInputType } from '@typings/types';
+import { clientAxios } from '@utils/commonAxios';
+
+const addComment = (commentInput: CommentInputType) =>
+  clientAxios.post('/v1/comments', {
+    ...commentInput,
+  });
+
+const useAddComment = (articleId: number) => {
+  const queryClient = useQueryClient();
+  return useAuthMutation(addComment, {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(['article', articleId]);
+      await queryClient.invalidateQueries(['comments', articleId]);
+    },
+  });
+};
+
+export default useAddComment;

--- a/frontend/src/hooks/queries/useDeleteComment.ts
+++ b/frontend/src/hooks/queries/useDeleteComment.ts
@@ -1,0 +1,18 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import useAuthMutation from '@hooks/useAuthMutation';
+import { clientAxios } from '@utils/commonAxios';
+
+const deleteComment = (commentId: number) => clientAxios.delete(`/v1/comments/${commentId}`);
+
+const useDeleteComment = (articleId: number) => {
+  const queryClient = useQueryClient();
+  return useAuthMutation(deleteComment, {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(['article', articleId]);
+      await queryClient.invalidateQueries(['comments', articleId]);
+    },
+  });
+};
+
+export default useDeleteComment;

--- a/frontend/src/hooks/queries/useFetchComments.ts
+++ b/frontend/src/hooks/queries/useFetchComments.ts
@@ -1,0 +1,33 @@
+import { AxiosError } from 'axios';
+
+import useAuthInfiniteQuery from '@hooks/useAuthInfiniteQuery';
+import { ApiResponseType, CommentType, PagingDataType } from '@typings/types';
+import { clientAxios } from '@utils/commonAxios';
+
+const getComments = async (currentPage: number, articleId: number) => {
+  const {
+    data: { data },
+  } = await clientAxios.get<ApiResponseType<PagingDataType<CommentType>>>('/v1/comments', {
+    params: {
+      articleId,
+      currentPage,
+      countPerPage: 5,
+    },
+  });
+  return data;
+};
+
+const useFetchComments = (articleId: number) => {
+  const { data: comments, ...rest } = useAuthInfiniteQuery<
+    PagingDataType<CommentType>,
+    AxiosError,
+    PagingDataType<CommentType>
+  >(['comments', articleId], ({ pageParam = 1 }) => getComments(pageParam, articleId), {
+    getNextPageParam: (lastPage) =>
+      lastPage.totalPage === lastPage.currentPage ? undefined : lastPage.currentPage + 1,
+  });
+
+  return { comments, ...rest };
+};
+
+export default useFetchComments;

--- a/frontend/src/hooks/queries/useFetchComments.ts
+++ b/frontend/src/hooks/queries/useFetchComments.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { AxiosError } from 'axios';
 
 import useAuthInfiniteQuery from '@hooks/useAuthInfiniteQuery';
@@ -18,7 +20,7 @@ const getComments = async (currentPage: number, articleId: number) => {
 };
 
 const useFetchComments = (articleId: number) => {
-  const { data: comments, ...rest } = useAuthInfiniteQuery<
+  const { data, ...rest } = useAuthInfiniteQuery<
     PagingDataType<CommentType>,
     AxiosError,
     PagingDataType<CommentType>
@@ -26,6 +28,8 @@ const useFetchComments = (articleId: number) => {
     getNextPageParam: (lastPage) =>
       lastPage.totalPage === lastPage.currentPage ? undefined : lastPage.currentPage + 1,
   });
+
+  const comments = useMemo(() => (data ? data.pages.flatMap(({ data }) => data) : []), [data]);
 
   return { comments, ...rest };
 };

--- a/frontend/src/hooks/queries/useFetchGroupArticles.ts
+++ b/frontend/src/hooks/queries/useFetchGroupArticles.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { AxiosError } from 'axios';
 
 import { ArticleStatus } from '@constants/article';
@@ -39,7 +41,7 @@ const useFetchGroupArticles = (
   location: Location | null,
   filterProgress: boolean
 ) => {
-  const queryResult = useAuthInfiniteQuery<ArticlePagingData, AxiosError, ArticlePagingData>(
+  const { data, ...rest } = useAuthInfiniteQuery<ArticlePagingData, AxiosError, ArticlePagingData>(
     ['articles', category, location, filterProgress],
     ({ pageParam = 1 }) => getGroupArticles(pageParam, category, location, filterProgress),
     {
@@ -48,7 +50,9 @@ const useFetchGroupArticles = (
     }
   );
 
-  return { ...queryResult };
+  const articles = useMemo(() => (data ? data.pages.flatMap(({ data }) => data) : []), [data]);
+
+  return { articles, ...rest };
 };
 
 export default useFetchGroupArticles;

--- a/frontend/src/hooks/useAuthInfiniteQuery.ts
+++ b/frontend/src/hooks/useAuthInfiniteQuery.ts
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+
 import {
   QueryFunction,
   QueryKey,
@@ -21,10 +23,11 @@ const useAuthInfiniteQuery = <
     'queryKey' | 'queryFn'
   >
 ) => {
+  const { isReady } = useRouter();
   const { error, ...rest } = useInfiniteQuery<TQueryFnData, TError, TData, TQueryKey>(
     queryKey,
     queryFn,
-    options
+    { ...options, enabled: isReady && options.enabled }
   );
   if (error && error instanceof AxiosError) {
     if (error.response.status === 401) {

--- a/frontend/src/pages/article/[id].tsx
+++ b/frontend/src/pages/article/[id].tsx
@@ -6,6 +6,8 @@ import styled from '@emotion/styled';
 import { Progress, TypographyStylesProvider } from '@mantine/core';
 import { IconList } from '@tabler/icons';
 
+import Comment from '@components/article/Comment';
+import CommentInput from '@components/article/CommentInput';
 import MenuButton from '@components/article/MenuButton';
 import ParticipantsModal from '@components/article/ParticipantsModal';
 import ParticipateButton from '@components/article/ParticipateButton';
@@ -14,6 +16,7 @@ import ArticleTag from '@components/common/ArticleTag';
 import Avatar from '@components/common/Avatar';
 import Header from '@components/common/Header';
 import DetailTitle from '@components/common/Header/DetailTitle';
+import Joiner from '@components/common/Joiner';
 import PageLayout from '@components/common/PageLayout';
 import StatCounter from '@components/common/StatCounter';
 import { ArticleStatus, ArticleStatusKr } from '@constants/article';
@@ -26,6 +29,7 @@ import { ParticipateButtonStatus } from '@constants/participateButton';
 import useFetchApplicationStatus from '@hooks/queries/useFetchApplicationStatus';
 import useFetchArticle from '@hooks/queries/useFetchArticle';
 import useFetchChatUrl from '@hooks/queries/useFetchChatUrl';
+import useFetchComments from '@hooks/queries/useFetchComments';
 import useFetchMyInfo from '@hooks/queries/useFetchMyInfo';
 import { ArticleType } from '@typings/types';
 import dateTimeFormat from '@utils/dateTime';
@@ -43,6 +47,7 @@ const ArticleDetail = () => {
     articleId,
     getButtonStatus(article, isJoined) === ParticipateButtonStatus.LINK
   );
+  const { comments } = useFetchComments(articleId);
 
   const [participantsModalOpen, setParticipantsModalOpen] = useState<boolean>(false);
 
@@ -66,10 +71,10 @@ const ArticleDetail = () => {
             }
           />
         }
+        footer={<CommentInput />}
       >
         <>
           <ContentWrapper>
-            {/* TODO 로딩 처리 */}
             {!article || isJoined === undefined || !myInfo ? (
               <ArticleLoading />
             ) : (
@@ -134,14 +139,19 @@ const ArticleDetail = () => {
                   )}
                   <StatCounter variant="comment" count={article.commentCount} />
                 </DetailWrapper>
-                <Divider />
-                <CommentWrapper>
-                  <div>댓글영역</div>
-                </CommentWrapper>
               </>
             )}
           </ContentWrapper>
+
           {/* TODO participants API 요청 */}
+          <Joiner
+            before
+            after
+            components={comments.map((comment) => (
+              <Comment key={comment.id} comment={comment} />
+            ))}
+          />
+
           <ParticipantsModal
             participants={dummyParticipants}
             open={participantsModalOpen}
@@ -149,7 +159,6 @@ const ArticleDetail = () => {
           />
         </>
       </PageLayout>
-      r
     </>
   );
 };
@@ -262,15 +271,4 @@ const ContentBox = styled.div`
   padding: 1.6rem;
   border: 1px solid ${({ theme }) => theme.colors.gray[2]};
   border-radius: 8px;
-`;
-
-const CommentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const Divider = styled.div`
-  width: 100%;
-  height: 0.05rem;
-  background-color: ${({ theme }) => theme.colors.gray[4]};
 `;

--- a/frontend/src/pages/article/[id].tsx
+++ b/frontend/src/pages/article/[id].tsx
@@ -88,7 +88,7 @@ const ArticleDetail = () => {
       >
         <>
           <ContentWrapper>
-            {!article || isJoined === undefined || !myInfo ? (
+            {!article || isJoined === undefined || !myInfo || !participants ? (
               <ArticleLoading />
             ) : (
               <>
@@ -137,7 +137,7 @@ const ArticleDetail = () => {
                     </ParticipantButton>
                   </ParticipantWrapper>
                   <Progress
-                    value={(article.currentCapacity / article.maxCapacity) * 100}
+                    value={(participants.length / article.maxCapacity) * 100}
                     size="lg"
                     radius="lg"
                     color={indigo[7]}
@@ -154,6 +154,11 @@ const ArticleDetail = () => {
                   )}
                   <StatCounter variant="comment" count={article.commentCount} />
                 </DetailWrapper>
+                <ParticipantsModal
+                  participants={participants}
+                  open={participantsModalOpen}
+                  onClose={() => setParticipantsModalOpen(false)}
+                />
               </>
             )}
           </ContentWrapper>
@@ -167,11 +172,6 @@ const ArticleDetail = () => {
             ))}
           />
           <div ref={ref}></div>
-          <ParticipantsModal
-            participants={participants}
-            open={participantsModalOpen}
-            onClose={() => setParticipantsModalOpen(false)}
-          />
         </>
       </PageLayout>
     </>

--- a/frontend/src/pages/article/[id].tsx
+++ b/frontend/src/pages/article/[id].tsx
@@ -151,7 +151,6 @@ const ArticleDetail = () => {
               <Comment key={comment.id} comment={comment} />
             ))}
           />
-
           <ParticipantsModal
             participants={dummyParticipants}
             open={participantsModalOpen}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -31,7 +31,7 @@ const Main = () => {
   const [selectedLocation, setSelectedLocation] = useState<Location | null>(null);
   const [progressChecked, setProgressChecked] = useState<boolean>(false);
 
-  const { data, fetchNextPage, hasNextPage, isFetching } = useFetchGroupArticles(
+  const { articles, fetchNextPage, hasNextPage, isFetching } = useFetchGroupArticles(
     selectedCategory,
     selectedLocation,
     progressChecked
@@ -42,8 +42,6 @@ const Main = () => {
       void fetchNextPage();
     }
   });
-
-  const articles = useMemo(() => (data ? data.pages.flatMap(({ data }) => data) : []), [data]);
 
   const refreshArticleList = () => {
     void queryClient.resetQueries(['articles']);

--- a/frontend/src/pages/user/[id].tsx
+++ b/frontend/src/pages/user/[id].tsx
@@ -11,7 +11,8 @@ import useFetchProfile from '@hooks/queries/useFetchProfile';
 
 const UserProfile = () => {
   const {
-    query: { id, isReady },
+    query: { id },
+    isReady,
   } = useRouter();
   const { profile, isFetching } = useFetchProfile(Number(id));
 

--- a/frontend/src/typings/types.ts
+++ b/frontend/src/typings/types.ts
@@ -64,6 +64,10 @@ interface CommentType {
   createdAt: string;
 }
 
+interface CommentInputType extends Pick<CommentType, 'contents'> {
+  articleId: number;
+}
+
 interface TestResponseType {
   dataArr: string[];
   isLast: boolean;
@@ -104,6 +108,7 @@ export type {
   PagingDataType,
   TestResponseType,
   CommentType,
+  CommentInputType,
   UserType,
   ImageUploadType,
   NotificationType,

--- a/frontend/src/typings/types.ts
+++ b/frontend/src/typings/types.ts
@@ -5,7 +5,20 @@ import { Category } from '@constants/category';
 import { Location } from '@constants/location';
 import { Notification } from '@constants/notification';
 
-interface ArticleThumbnail {
+interface PagingDataType<T> {
+  totalPage: number;
+  currentPage: number;
+  countPerPage: number;
+  data: T;
+}
+
+interface ApiResponseType<T> {
+  status: string;
+  message: string;
+  data: T;
+}
+
+interface ArticleThumbnailType {
   originUrl: string;
   blurUrl: string;
 }
@@ -17,7 +30,7 @@ interface ArticlePreviewType {
   category: Category;
   commentCount: number;
   scrapCount: number;
-  thumbnail: ArticleThumbnail;
+  thumbnail: ArticleThumbnailType;
   maxCapacity: number;
   currentCapacity: number;
   status: ArticleStatus;
@@ -83,10 +96,12 @@ interface NotificationType {
 
 export type {
   ApiResponse,
+  ApiResponseType,
   ArticlePreviewType,
   ArticleType,
   MyArticleType,
   ArticlePostInputType,
+  PagingDataType,
   TestResponseType,
   CommentType,
   UserType,


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- [x] 댓글 조회
  - 무한스크롤 적용
  ![댓글무한스크롤](https://user-images.githubusercontent.com/38908080/206220948-21010563-83a1-47ca-881c-c41ed91a97c3.gif)


- [x] 댓글 입력창 활성화
  - 댓글입력창에 내용이 있는 경우에만 버튼이 활성화
   
  ![댓글입력](https://user-images.githubusercontent.com/38908080/206221348-c8d33554-91f1-4ee5-8cc2-40c301c4e0e6.gif)


- [x] 댓글 추가
  - 댓글 추가 시 댓글 목록에서 제일 아래로 이동하도록 함
  - 엔터키 입력시에도 댓글이 추가되도록 대응

  ![댓글추가](https://user-images.githubusercontent.com/38908080/206221653-6a12f8a4-7896-4390-a4a1-67c1202a1d01.gif)



- [x] 댓글 삭제

  ![댓글 삭제](https://user-images.githubusercontent.com/38908080/206221931-5a1306fa-57af-4d45-9b1f-27f28001d441.gif)



## 문제 상황과 해결(백엔드분들도 한번 읽어주세요)

### 댓글 추가나 삭제 관련

```tsx
const useAddComment = (articleId: number) => {
  const queryClient = useQueryClient();
  return useAuthMutation(addComment, {
    onSuccess: async () => {
      await queryClient.invalidateQueries(['article', articleId]);
      await queryClient.invalidateQueries(['comments', articleId]);
    },
  });
};
```

- 댓글의 개수는 `/v1/group-articles/{id}`에서 조회되는 한편, 댓글의 내용들은 `/v1/comments` 에서 불러오고 있습니다.
- 이때 댓글 추가나 삭제가 발생해서 `댓글 내용 변경`과 `댓글 개수 변경`을 일으키려면 위와 같이 두 개의 쿼리를 무효화해야되는 상황이 발생합니다. 
- `['article', articleId]` 쿼리 무효화의 경우 댓글의 개수만 바뀔뿐인데 게시글 내용까지 다소 조회해야하는 다소 비효율적인 방식으로 동작합니다.
- 그래서 제 생각에는 `댓글의 총 개수`를 `/v1/comments`에 통합시켜야 되겠다라는 생각이 듭니다.

## 비고