### PR TITLE
[Feature] 에러 처리 - GET 에러 발생 modal

### DIFF
--- a/frontend/src/components/common/ErrorBoundary/ApiErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary/ApiErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import { Component, PropsWithChildren, useState } from 'react';
 
 import { AxiosError } from 'axios';
@@ -35,13 +36,13 @@ class ApiErrorBoundary extends Component<Props, State> {
     if (!error) return children;
 
     if (error instanceof GetError) {
-      return <ApiErrorModal message={error.message} />;
+      return <GetErrorModal message={error.message} />;
     }
     if (error instanceof RequestError) {
       return (
         <>
           {children}
-          <ApiErrorModal message={error.message} />
+          <RequestErrorModal message={error.message} />
         </>
       );
     }
@@ -50,7 +51,22 @@ class ApiErrorBoundary extends Component<Props, State> {
 
 export default ApiErrorBoundary;
 
-const ApiErrorModal = ({ message }: { message: string }) => {
+const GetErrorModal = ({ message }: { message: string }) => {
+  const router = useRouter();
+  const [open, setOpen] = useState<boolean>(true);
+  return (
+    <AlertModal
+      open={open}
+      onClose={() => {
+        setOpen(false);
+        router.back();
+      }}
+      message={message}
+    />
+  );
+};
+
+const RequestErrorModal = ({ message }: { message: string }) => {
   const [open, setOpen] = useState<boolean>(true);
   return <AlertModal open={open} onClose={() => setOpen(false)} message={message} />;
 };

--- a/frontend/src/components/common/ErrorMessage/index.tsx
+++ b/frontend/src/components/common/ErrorMessage/index.tsx
@@ -39,6 +39,8 @@ const MessageWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  max-width: 600px;
   height: 100vh;
 `;
 

--- a/frontend/src/hooks/useAuthInfiniteQuery.ts
+++ b/frontend/src/hooks/useAuthInfiniteQuery.ts
@@ -9,6 +9,7 @@ import {
 import { AxiosError } from 'axios';
 
 import AuthError from '@utils/errors/AuthError';
+import GetError from '@utils/errors/GetError';
 
 const useAuthInfiniteQuery = <
   TQueryFnData = unknown,
@@ -33,7 +34,7 @@ const useAuthInfiniteQuery = <
     if (error.response.status === 401) {
       throw new AuthError();
     }
-    throw error;
+    throw new GetError(error.response.data.message);
   }
   return { ...rest };
 };

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -52,16 +52,16 @@ export default function App({ Component, pageProps }: AppProps<{ dehydratedState
           <ReactQueryDevtools initialIsOpen={false} />
           <CommonStyles>
             <RouterTransition />
+            <Background />
             <ErrorBoundary key={uuid()}>
               <AuthErrorBoundary>
                 <ApiErrorBoundary>
                   <LoginRedirect />
-                  <Background />
                   <Component {...pageProps} />
-                  <Background />
                 </ApiErrorBoundary>
               </AuthErrorBoundary>
             </ErrorBoundary>
+            <Background />
           </CommonStyles>
         </Hydrate>
       </QueryClientProvider>


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- GET에러 발생 시 오픈되는 modal의 [확인 button]을 누르면 이전 페이지로 돌아가도록 했습니다.
  - 기존 구현 상으로는 버튼 클릭 시 modal이 닫히도록 되어 있었습니다.
  - 이 경우 알림 페이지에서 게시글 클릭 시, 해당 게시글이 삭제되어 존재하지 않는다면 modal이 열리고 확인버튼 클릭 시 modal이 닫혀 흰 화면을 보게 됩니다.
  - 이런 상황에서는 확인 버튼 클릭 시 이전 페이지로 돌려보내주는 것이 좋은 방법이라 생각했습니다.
- 기존에 한 페이지 내의 특정 컴포넌트에서 GET에러가 발생했을 때, 다른 컴포넌트들은 정상적으로 렌더링시켜주기 위해 단순히 modal을 띄워 에러 상황을 알리기만 하고 다른 작업(redirect, refresh 등)은 추가하지 않았습니다. 하지만 모여모여 서비스 특성 상 보통 한 페이지 내에서 하나의 GET 요청에 대한 데이터/에러가 페이지 전체에 영향을 미치기 때문에, 굳이 컴포넌트별로 나눠 렌더링해주지 않고 이전 페이지로 돌려보내주어도 큰 문제가 없을것이라 판단했습니다.


## 문제 상황과 해결


## 비고

