### PR TITLE
[BUGFIX] 내가 참여한 모임 조회 페이지네이션

### DIFF
--- a/backend/src/app/comment/comment.controller.ts
+++ b/backend/src/app/comment/comment.controller.ts
@@ -50,14 +50,15 @@ export class CommentController {
   @ApiSuccessResponse(HttpStatus.OK, GroupArticleCommentGetResponse)
   @ApiErrorResponse(GroupNotFoundException)
   async getComment(@Query() query: GetAllCommentQueryRequest) {
-    const { count, commentResponse } = await this.commentService.getComment({
-      limit: query.getLimit(),
-      offset: query.getOffset(),
-      articleId: query.articleId,
-    });
+    const { totalCount, commentResponse } =
+      await this.commentService.getComment({
+        limit: query.getLimit(),
+        offset: query.getOffset(),
+        articleId: query.articleId,
+      });
 
     const data = new GroupArticleCommentGetResponse(
-      count,
+      totalCount,
       query.currentPage,
       query.countPerPage,
       commentResponse,

--- a/backend/src/app/comment/comment.repository.ts
+++ b/backend/src/app/comment/comment.repository.ts
@@ -12,14 +12,7 @@ export class CommentRepository extends Repository<Comment> {
     );
   }
 
-  getTotalCount(articleId: number) {
-    return this.countBy({
-      articleId,
-      deletedAt: IsNull(),
-    });
-  }
-
-  selectAllComments({
+  async selectAllComments({
     limit,
     offset,
     articleId,
@@ -28,7 +21,7 @@ export class CommentRepository extends Repository<Comment> {
     offset: number;
     articleId: number;
   }) {
-    return this.find({
+    const [allCommentList, totalCount] = await this.findAndCount({
       relations: {
         user: true,
       },
@@ -39,6 +32,8 @@ export class CommentRepository extends Repository<Comment> {
       take: limit,
       skip: offset,
     });
+
+    return { allCommentList, totalCount };
   }
 
   findById(id: number) {

--- a/backend/src/app/comment/comment.service.ts
+++ b/backend/src/app/comment/comment.service.ts
@@ -57,15 +57,14 @@ export class CommentService {
   }) {
     const groupArticle = await this.groupArticleRepository.findById(articleId);
     this.validateArticle(groupArticle);
-    const allCommentList = await this.commentRepository.selectAllComments({
-      articleId,
-      limit,
-      offset,
-    });
-
-    const count = await this.commentRepository.getTotalCount(articleId);
+    const { allCommentList, totalCount } =
+      await this.commentRepository.selectAllComments({
+        articleId,
+        limit,
+        offset,
+      });
     const commentResponse = await this.bindCommentResponse(allCommentList);
-    return { count, commentResponse };
+    return { totalCount, commentResponse };
   }
 
   bindCommentResponse(allCommentList: Comment[]) {

--- a/backend/src/app/group-application/dto/my-application-result.interface.ts
+++ b/backend/src/app/group-application/dto/my-application-result.interface.ts
@@ -1,0 +1,5 @@
+export interface IMyApplicationResult {
+  id: number;
+
+  groupId: number;
+}

--- a/backend/src/app/group-application/group-application.controller.ts
+++ b/backend/src/app/group-application/group-application.controller.ts
@@ -106,13 +106,14 @@ export class GroupApplicationController {
   @Get('me')
   @ApiSuccessResponse(HttpStatus.OK, MyGroupResponse)
   async findMyGroup(@CurrentUser() user: User, @Query() query: MyGroupRequest) {
-    const { response, count } = await this.groupApplicationService.findMyGroup({
-      user,
-      limit: query.getLimit(),
-      offset: query.getOffset(),
-    });
+    const { response, totalCount } =
+      await this.groupApplicationService.findMyGroup({
+        user,
+        limit: query.getLimit(),
+        offset: query.getOffset(),
+      });
     const data = new MyGroupResponse(
-      count,
+      totalCount,
       query.currentPage,
       query.countPerPage,
       response,

--- a/backend/src/app/group-application/group-application.service.ts
+++ b/backend/src/app/group-application/group-application.service.ts
@@ -177,18 +177,16 @@ export class GroupApplicationService {
     limit: number;
     offset: number;
   }) {
-    const result = await this.groupApplicationRepository.findMyGroup({
-      userId: user.id,
-      limit,
-      offset,
-    });
+    const { result, totalCount } =
+      await this.groupApplicationRepository.findMyGroup({
+        userId: user.id,
+        limit,
+        offset,
+      });
     const response = await Promise.all(
       result.map((value) => GroupArticleResponse.from(value)),
     );
-    const count = await this.groupApplicationRepository.findMyGroupCount(
-      user.id,
-    );
-    return { response, count };
+    return { response, totalCount };
   }
 
   public async getAllParticipants(user: User, groupArticleId: number) {


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 삭제된 게시글때문에 페이지네이션이 누락되는 것을 고침
- 아래 쿼리빌더로 변경함 

```
const groupApplicationsQuery = this.createQueryBuilder('groupApplication')
      .select([
        'groupApplication.id as id',
        'groupApplication.groupId as groupId',
      ])
      .leftJoin(Group, 'group', 'groupApplication.group_id = group.id')
      .leftJoin(
        GroupArticle,
        'groupArticle',
        'groupArticle.id = group.article_id',
      )
      .where('groupApplication.deletedAt IS NULL')
      .andWhere('groupApplication.user_id = :id', { id: userId })
      .andWhere('groupArticle.deletedAt IS NULL');

    const totalCount = await groupApplicationsQuery.clone().getCount();
    const groupApplications = await groupApplicationsQuery
      .limit(limit)
      .offset(offset)
      .getRawMany<IMyApplicationResult>();
``` 

## 비고

- 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 