### PR TITLE
[BUGFIX] 모집완료시 마지막 참가신청자에게 알림이 가지 않는 문제

### DIFF
--- a/backend/src/app/group-application/group-application.service.ts
+++ b/backend/src/app/group-application/group-application.service.ts
@@ -75,8 +75,8 @@ export class GroupApplicationService {
     });
 
     const groupApplication = GroupApplication.create(user, group);
-    const result = this.groupApplicationRepository.save(groupApplication);
-    this.checkGroupComplete(groupArticle, groupApplicationCount);
+    const result = await this.groupApplicationRepository.save(groupApplication);
+    await this.checkGroupComplete(groupArticle, groupApplicationCount);
     return result;
   }
 
@@ -109,13 +109,13 @@ export class GroupApplicationService {
     }
   }
 
-  private checkGroupComplete(
+  private async checkGroupComplete(
     groupArticle: GroupArticle,
     groupApplicationCount: number,
   ) {
     if (groupArticle.group.maxCapacity <= groupApplicationCount + 1) {
       groupArticle.group.complete();
-      this.groupArticleRepository.save(groupArticle);
+      await this.groupArticleRepository.save(groupArticle);
       this.eventEmitter.emit(
         'group.succeed',
         new GroupSucceedEvent(groupArticle),


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 모집완료시 마지막 참가신청자에게 알림이 가지 않는 문제해결
- 비동기 처리를 제대로 하지 않았던 것이 문제가 됐던 것 같습니다.

```typescript
  private async checkGroupComplete(
    groupArticle: GroupArticle,
    groupApplicationCount: number,
  ) {
    if (groupArticle.group.maxCapacity <= groupApplicationCount + 1) {
      groupArticle.group.complete();
      await this.groupArticleRepository.save(groupArticle);
      this.eventEmitter.emit(
        'group.succeed',
        new GroupSucceedEvent(groupArticle),
      );
    }
  }
```
