### PR TITLE
[Feature] 플로팅 화면 위치를 모바일 화면 안으로 넣기

### DIFF
--- a/frontend/src/components/common/FloatingButton/styles.tsx
+++ b/frontend/src/components/common/FloatingButton/styles.tsx
@@ -9,7 +9,10 @@ const _FABWrapper = styled(ActionIcon)`
   position: fixed;
   bottom: 7.2rem;
   right: 1.6rem;
-  z-index: 100;
+  z-index: 200;
+  @media screen and (min-width: 600px) {
+    right: calc(50vw - 300px + 1.6rem);
+  }
 `;
 
 const FABWrapper = createPolymorphicComponent<'button', ActionIconProps>(_FABWrapper);


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

![이왜됨](https://user-images.githubusercontent.com/38908080/206887250-e16c6350-9e48-46aa-93c8-af688174f80e.gif)

- 플로팅 화면 위치를 모바일 화면 내부로 넣었습니다.

## 문제 상황과 해결


## 비고

