### PR TITLE
[Feature] 이미지 프리로드, 댓글 삭제시 추가된 댓글 안보이게 수정

### DIFF
--- a/frontend/src/components/common/GroupArticleCard/index.tsx
+++ b/frontend/src/components/common/GroupArticleCard/index.tsx
@@ -45,10 +45,11 @@ const GroupArticleCard = ({ article }: Props) => {
           alt={'thumbnail-image'}
           layout="fill"
           objectFit="cover"
-          sizes="(min-width: 800px) 300px,150px"
+          sizes="(min-width: 600px) 300px,150px"
           placeholder="blur"
           blurDataURL={blurUrl}
-          style={{ transition: '0.3s ease-in-out' }}
+          style={{ transition: '0.2s ease-in-out' }}
+          priority
         />
       </ImageWrapper>
       <InfoWrapper>

--- a/frontend/src/pages/article/[id].tsx
+++ b/frontend/src/pages/article/[id].tsx
@@ -167,7 +167,11 @@ const ArticleDetail = () => {
               <Joiner
                 {...(comments.length > 0 && { before: true })}
                 components={comments.map((comment) => (
-                  <Comment key={comment.id} comment={comment} />
+                  <Comment
+                    key={comment.id}
+                    comment={comment}
+                    onDeleteComment={() => setAddedComment(null)}
+                  />
                 ))}
               />
               <div ref={ref}></div>


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 이미지 프리로딩을 적용하였습니다.
    - 적용 전
  
    <img width="930" alt="image" src="https://user-images.githubusercontent.com/38908080/207765357-817247d6-fe44-400d-9ffb-d4fd235c09e1.png">

    
  - 적용 후
 
   <img width="930" alt="image" src="https://user-images.githubusercontent.com/38908080/207765274-8d4dcc50-dcdb-4169-903f-491ae2ad26af.png">

- 댓글 삭제 시 추가된 댓글 안보이게 수정

## 문제 상황과 해결


## 비고

