### PR TITLE
[BUGFIX] 사파리 알림 컴포넌트 깨짐 현상

### DIFF
--- a/frontend/src/components/notification/NotificationItem/NotificationItem.stories.tsx
+++ b/frontend/src/components/notification/NotificationItem/NotificationItem.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import styled from '@emotion/styled';
+
 import { Notification } from '@constants/notification';
 
 import NotificationItem from '.';
@@ -37,6 +39,38 @@ GroupSuccess.args = {
 
 export const GroupFail = Template.bind({});
 GroupFail.args = {
+  notification: {
+    id: 1,
+    type: Notification.GROUP_FAILED,
+    title: '모임이 무산되었어요.',
+    subTitle: '캐럿스터디 - 인천',
+    groupArticleId: 3,
+    createdAt: '2021-08-01T00:00:00.000Z',
+  },
+};
+
+const PageWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 1.6rem;
+  gap: 1.6rem;
+`;
+
+const PageTemplate: ComponentStory<typeof NotificationItem> = (args) => (
+  <PageWrapper>
+    <NotificationItem {...args} />
+    <NotificationItem {...args} />
+    <NotificationItem {...args} />
+    <NotificationItem {...args} />
+    <NotificationItem {...args} />
+    <NotificationItem {...args} />
+  </PageWrapper>
+);
+
+export const Collection = PageTemplate.bind({});
+Collection.args = {
   notification: {
     id: 1,
     type: Notification.GROUP_FAILED,

--- a/frontend/src/components/notification/NotificationItem/index.tsx
+++ b/frontend/src/components/notification/NotificationItem/index.tsx
@@ -46,7 +46,12 @@ const NotificationItem = ({ notification }: Props) => {
               >
                 {title}
               </Text>
-              <Text size="sm" color="gray" weight={500}>
+              <Text
+                size="sm"
+                color="gray"
+                weight={500}
+                sx={{ whiteSpace: 'nowrap', overflowX: 'hidden', textOverflow: 'ellipsis' }}
+              >
                 {subTitle}
               </Text>
             </TitleWrapper>

--- a/frontend/src/components/notification/NotificationItem/index.tsx
+++ b/frontend/src/components/notification/NotificationItem/index.tsx
@@ -25,58 +25,60 @@ const NotificationItem = ({ notification }: Props) => {
   const [confirmModalOpen, setConfirmModalOpen] = useState(false);
 
   return (
-    <NotificationWrapper>
+    <>
       <ConfirmModal
         message="알림을 삭제하시겠습니까?"
         open={confirmModalOpen}
         onConfirmButtonClick={() => deleteNotification(notification.id)}
         onCancelButtonClick={() => setConfirmModalOpen(false)}
       />
-      <Link href={`/article/${notification.groupArticleId}`}>
-        <ContentSection>
-          <IconWrapper>
-            <NotificationIcon variant={type} />
-          </IconWrapper>
-          <TitleWrapper>
-            <Text
-              size="md"
-              weight={700}
-              sx={{ whiteSpace: 'nowrap', overflowX: 'hidden', textOverflow: 'ellipsis' }}
-            >
-              {title}
-            </Text>
-            <Text size="sm" color="gray" weight={500}>
-              {subTitle}
-            </Text>
-          </TitleWrapper>
-        </ContentSection>
-      </Link>
-      <AsideSection>
-        <ActionIcon
-          variant="transparent"
-          color="gray.6"
-          size="sm"
-          onClick={() => setConfirmModalOpen(true)}
-        >
-          <IconX size={20} />
-        </ActionIcon>
-        <Text size="xs" weight={500} c="gray.6">
-          {dateTimeFormat(createdAt)}
-        </Text>
-      </AsideSection>
-    </NotificationWrapper>
+      <NotificationWrapper>
+        <Link href={`/article/${notification.groupArticleId}`}>
+          <ContentSection>
+            <IconWrapper>
+              <NotificationIcon variant={type} />
+            </IconWrapper>
+            <TitleWrapper>
+              <Text
+                size="md"
+                weight={700}
+                sx={{ whiteSpace: 'nowrap', overflowX: 'hidden', textOverflow: 'ellipsis' }}
+              >
+                {title}
+              </Text>
+              <Text size="sm" color="gray" weight={500}>
+                {subTitle}
+              </Text>
+            </TitleWrapper>
+          </ContentSection>
+        </Link>
+        <AsideSection>
+          <ActionIcon
+            variant="transparent"
+            color="gray.6"
+            size="sm"
+            onClick={() => setConfirmModalOpen(true)}
+          >
+            <IconX size={20} />
+          </ActionIcon>
+          <Text size="xs" weight={500} c="gray.6">
+            {dateTimeFormat(createdAt)}
+          </Text>
+        </AsideSection>
+      </NotificationWrapper>
+    </>
   );
 };
 
 export default NotificationItem;
 
 const NotificationWrapper = styled.div`
-  display: grid;
   align-items: center;
-  grid-template-columns: 1fr 5rem;
+  display: flex;
   gap: 1.6rem;
   padding: 1.6rem;
   width: 100%;
+  height: 100%;
   border: 1px solid ${({ theme }) => theme.colors.gray[2]};
   border-radius: 0.8rem;
 `;
@@ -102,13 +104,15 @@ const TitleWrapper = styled.div`
   flex-direction: column;
   gap: 0.8rem;
   overflow-x: hidden;
+  white-space: nowrap;
 `;
 
 const AsideSection = styled.div`
   height: 100%;
   display: flex;
+  flex: 1;
   flex-direction: column;
   align-items: flex-end;
   justify-content: space-between;
-  min-width: 4rem;
+  white-space: nowrap;
 `;


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 사파리 및 ios에서 알림 컴포넌트가 깨지는 현상을 수정했습니다. 수정된 결과는 [여기서](https://637c707cf24ecaa36bad2e45-dcsrxqyxnc.chromatic.com/?path=/story/component-notificationitem--collection) 확인할 수 있습니다. 사파리로 들어가보세요

## 문제 상황과 해결

- 원인은 정확히 알 수 없으나 현재는 [flex 속성이 사파리 브라우저 상에서 제대로 상속되지 않는 버그](http://vnthf.logdown.com/posts/2016/10/07/safari-flex-height)가 있는 것으로 추측하고 있습니다.

- 이를 바탕으로 `NotificationWrapper`에 `display:grid`를 없애고 flex를 적용하여 상속이 제대로 이뤄지도록 했습니다.

## 비고

- [사파리 flex 상속 버그](http://vnthf.logdown.com/posts/2016/10/07/safari-flex-height)
