### PR TITLE
[Refector] event 관리 코드 수정

### DIFF
--- a/backend/src/app/comment/comment.service.ts
+++ b/backend/src/app/comment/comment.service.ts
@@ -33,8 +33,8 @@ export class CommentService {
     );
 
     const result = await this.commentRepository.save(comment);
-    this.eventEmitter.emit(
-      'comment.added',
+    await this.eventEmitter.emitAsync(
+      CommentAddedEvent.event,
       new CommentAddedEvent(groupArticle, result),
     );
     return result;

--- a/backend/src/app/group-application/group-application.service.ts
+++ b/backend/src/app/group-application/group-application.service.ts
@@ -117,7 +117,7 @@ export class GroupApplicationService {
       groupArticle.group.complete();
       await this.groupArticleRepository.save(groupArticle);
       this.eventEmitter.emit(
-        'group.succeed',
+        GroupSucceedEvent.event,
         new GroupSucceedEvent(groupArticle),
       );
     }

--- a/backend/src/app/group-article/group-article.service.ts
+++ b/backend/src/app/group-article/group-article.service.ts
@@ -112,7 +112,10 @@ export class GroupArticleService {
 
     await this.groupArticleRepository.save(groupArticle, { reload: false });
 
-    this.eventEmitter.emit('group.failed', new GroupFailedEvent(groupArticle));
+    await this.eventEmitter.emitAsync(
+      GroupFailedEvent.event,
+      new GroupFailedEvent(groupArticle),
+    );
   }
 
   async getDetailById(id: number) {

--- a/backend/src/app/group-article/group-article.service.ts
+++ b/backend/src/app/group-article/group-article.service.ts
@@ -92,8 +92,8 @@ export class GroupArticleService {
 
     await this.groupArticleRepository.save(groupArticle, { reload: false });
 
-    this.eventEmitter.emit(
-      'group.succeed',
+    await this.eventEmitter.emitAsync(
+      GroupSucceedEvent.event,
       new GroupSucceedEvent(groupArticle),
     );
   }

--- a/backend/src/app/notification/event/comment-added.event.ts
+++ b/backend/src/app/notification/event/comment-added.event.ts
@@ -2,6 +2,7 @@ import { GroupArticle } from '@app/group-article/entity/group-article.entity';
 import { Comment } from '@src/app/comment/entity/comment.entity';
 
 export class CommentAddedEvent {
+  static readonly event = 'comment.added';
   groupArticle: GroupArticle;
   comment: Comment;
 

--- a/backend/src/app/notification/event/group-failed.event.ts
+++ b/backend/src/app/notification/event/group-failed.event.ts
@@ -1,6 +1,7 @@
 import { GroupArticle } from '@app/group-article/entity/group-article.entity';
 
 export class GroupFailedEvent {
+  static readonly event = 'group.failed';
   groupArticle: GroupArticle;
 
   constructor(groupArticle: GroupArticle) {

--- a/backend/src/app/notification/event/group-succeed.event.ts
+++ b/backend/src/app/notification/event/group-succeed.event.ts
@@ -1,6 +1,7 @@
 import { GroupArticle } from '@app/group-article/entity/group-article.entity';
 
 export class GroupSucceedEvent {
+  static readonly event = 'group.succeed';
   groupArticle: GroupArticle;
 
   constructor(groupArticle: GroupArticle) {

--- a/backend/src/app/notification/notification.listener.ts
+++ b/backend/src/app/notification/notification.listener.ts
@@ -70,7 +70,7 @@ export class NotificationListener {
     }
   }
 
-  @OnEvent('group.failed')
+  @OnEvent(GroupFailedEvent.event, { async: true })
   async handleGroupFailedEvent(event: GroupFailedEvent) {
     const { groupArticle } = event;
 

--- a/backend/src/app/notification/notification.listener.ts
+++ b/backend/src/app/notification/notification.listener.ts
@@ -116,7 +116,7 @@ export class NotificationListener {
     }
   }
 
-  @OnEvent('comment.added')
+  @OnEvent(CommentAddedEvent.event, { async: true })
   async handleCommentAddedEvent(event: CommentAddedEvent) {
     const { groupArticle, comment } = event;
     try {

--- a/backend/src/app/notification/notification.listener.ts
+++ b/backend/src/app/notification/notification.listener.ts
@@ -24,7 +24,7 @@ export class NotificationListener {
     private readonly sseService: SseService,
   ) {}
 
-  @OnEvent('group.succeed')
+  @OnEvent(GroupSucceedEvent.event, { async: true })
   async handleGroupSucceedEvent(event: GroupSucceedEvent) {
     const { groupArticle } = event;
 


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- NestJS에서 제공하는`@nestjs/event-emitter` 는 내부적으로 [event emitter2](https://github.com/EventEmitter2/EventEmitter2)를 사용하고 있다. 기존에도 정상적으로 동작하긴 했으나 사용법이 적절하지 못해 수정했다.

기존에는 아래와 같이 비동기함수인 event listenr를 단순히 emit해 우회적으로 동작시켰다.
https://github.com/boostcampwm-2022/web13-moyeomoyeo/blob/399ce792c9434ddc800d034523e86cdd607c4df6/backend/src/app/group-article/group-article.service.ts#L95-L98

https://github.com/boostcampwm-2022/web13-moyeomoyeo/blob/399ce792c9434ddc800d034523e86cdd607c4df6/backend/src/app/notification/notification.listener.ts#L27-L30

async옵션을 통해 setImmediate를 사용해 비동기적으로 호출될 수 있도록 아래와 같이 변경했다.
https://github.com/boostcampwm-2022/web13-moyeomoyeo/blob/6f41f44fd39d9de21710768565abede21277b67e/backend/src/app/group-article/group-article.service.ts#L95-L98

https://github.com/boostcampwm-2022/web13-moyeomoyeo/blob/6f41f44fd39d9de21710768565abede21277b67e/backend/src/app/notification/notification.listener.ts#L27-L30

## 문제 상황과 해결

- 현재 async는 true로 두어 비동기적으로 setImmediate을 사용하도록 되어있다. `{ nextTick: true }` 옵션을 주어 next tick에 바로 실행되도록 할수도 있다. setImmediate는 이벤트 루프에 check phase에 실행되고 nextTick은 nextTickQueue에 담겨 다음 페이즈로 넘어가기전에 실행된다.

두 옵션 모두 비동기적으로 동작하게 할 수 있는데 어떤 옵션을 주는게 좋을까? 

## 비고

- 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
